### PR TITLE
Device::Load(): allow passing peerConnectionOptions

### DIFF
--- a/include/Device.hpp
+++ b/include/Device.hpp
@@ -18,7 +18,9 @@ public:
 
 	bool IsLoaded() const;
 	const nlohmann::json& GetRtpCapabilities() const;
-	void Load(const nlohmann::json& routerRtpCapabilities);
+	void Load(
+	  const nlohmann::json& routerRtpCapabilities,
+	  const PeerConnection::Options* peerConnectionOptions = nullptr);
 	bool CanProduce(const std::string& kind);
 
 	SendTransport* CreateSendTransport(

--- a/include/Handler.hpp
+++ b/include/Handler.hpp
@@ -27,7 +27,8 @@ public:
 	virtual void RestartIce(const nlohmann::json& iceParameters) = 0;
 
 public:
-	static nlohmann::json GetNativeRtpCapabilities();
+	static nlohmann::json GetNativeRtpCapabilities(
+	  const PeerConnection::Options* peerConnectionOptions = nullptr);
 
 public:
 	explicit Handler(

--- a/src/Device.cpp
+++ b/src/Device.cpp
@@ -14,7 +14,9 @@ namespace mediasoupclient
 /**
  * Initialize the Device.
  */
-void Device::Load(const json& routerRtpCapabilities)
+void Device::Load(
+  const json& routerRtpCapabilities,
+  const PeerConnection::Options* peerConnectionOptions)
 {
 	MSC_TRACE();
 
@@ -24,7 +26,7 @@ void Device::Load(const json& routerRtpCapabilities)
 		throw Exception("Missing routerRtpCapabilities");
 
 	// Get Native RTP capabilities.
-	auto nativeRtpCapabilities = Handler::GetNativeRtpCapabilities();
+	auto nativeRtpCapabilities = Handler::GetNativeRtpCapabilities(peerConnectionOptions);
 
 	// Get extended RTP capabilities.
 	this->extendedRtpCapabilities =

--- a/src/Handler.cpp
+++ b/src/Handler.cpp
@@ -16,21 +16,23 @@ namespace mediasoupclient
 {
 /* Handler static methods */
 
-json Handler::GetNativeRtpCapabilities()
+json Handler::GetNativeRtpCapabilities(
+  const PeerConnection::Options* peerConnectionOptions)
 {
 	MSC_TRACE();
 
 	std::unique_ptr<PeerConnection::PrivateListener> privateListener(
 	  new PeerConnection::PrivateListener());
-	std::unique_ptr<PeerConnection> pc(new PeerConnection(privateListener.get(), nullptr));
+	std::unique_ptr<PeerConnection> pc(
+	  new PeerConnection(privateListener.get(), peerConnectionOptions));
 
 	(void)pc->AddTransceiver(cricket::MediaType::MEDIA_TYPE_AUDIO);
 	(void)pc->AddTransceiver(cricket::MediaType::MEDIA_TYPE_VIDEO);
 
-	// May throw.
 	webrtc::PeerConnectionInterface::RTCOfferAnswerOptions options;
-	auto offer = pc->CreateOffer(options);
 
+	// May throw.
+	auto offer                 = pc->CreateOffer(options);
 	auto sdpObject             = sdptransform::parse(offer);
 	auto nativeRtpCapabilities = Sdp::Utils::extractRtpCapabilities(sdpObject);
 


### PR DESCRIPTION
- The app can then provide its own PeerConnectionFactory with its custom
  encoder/decoder and limited subset of supported codecs.
- Those settings would be reflected in device.GetRtpCapabilities().
- It should fix #56.