### PR TITLE
enable opusPtime parameter in codecOptions

### DIFF
--- a/src/sdp/MediaSection.cpp
+++ b/src/sdp/MediaSection.cpp
@@ -213,6 +213,13 @@ namespace mediasoupclient
 								auto opusMaxPlaybackRate           = opusMaxPlaybackRateIt->get<uint32_t>();
 								codecParameters["maxplaybackrate"] = opusMaxPlaybackRate;
 							}
+
+							auto opusPtimeIt = codecOptions->find("opusPtime");
+							if (opusPtimeIt != codecOptions->end())
+							{
+								auto opusPtime           = opusPtimeIt->get<uint32_t>();
+								codecParameters["ptime"] = opusPtime;
+							}
 						}
 						else if (mimeType == "video/vp8" || mimeType == "video/vp9" || mimeType == "video/h264" || mimeType == "video/h265")
 						{


### PR DESCRIPTION
Add this part to set ptime, and we can change opus encoder's frame size.