### PR TITLE
Fixes memory leak

### DIFF
--- a/include/sdp/RemoteSdp.hpp
+++ b/include/sdp/RemoteSdp.hpp
@@ -25,6 +25,7 @@ namespace mediasoupclient
 			  const nlohmann::json& iceCandidates,
 			  const nlohmann::json& dtlsParameters,
 			  const nlohmann::json& sctpParameters);
+			~RemoteSdp();
 
 		public:
 			Sdp::RemoteSdp::MediaSectionIdx GetNextMediaSectionIdx();

--- a/src/PeerConnection.cpp
+++ b/src/PeerConnection.cpp
@@ -445,11 +445,11 @@ namespace mediasoupclient
 		MSC_TRACE();
 
 		// This callback should take the ownership of |desc|.
-		std::unique_ptr<webrtc::SessionDescriptionInterface> owned_desc(desc);
+		std::unique_ptr<webrtc::SessionDescriptionInterface> ownedDesc(desc);
 
 		std::string sdp;
 
-		owned_desc->ToString(&sdp);
+		ownedDesc->ToString(&sdp);
 		this->promise.set_value(sdp);
 	};
 

--- a/src/PeerConnection.cpp
+++ b/src/PeerConnection.cpp
@@ -444,9 +444,12 @@ namespace mediasoupclient
 	{
 		MSC_TRACE();
 
+		// This callback should take the ownership of |desc|.
+		std::unique_ptr<webrtc::SessionDescriptionInterface> owned_desc(desc);
+
 		std::string sdp;
 
-		desc->ToString(&sdp);
+		owned_desc->ToString(&sdp);
 		this->promise.set_value(sdp);
 	};
 

--- a/src/sdp/RemoteSdp.cpp
+++ b/src/sdp/RemoteSdp.cpp
@@ -76,6 +76,15 @@ namespace mediasoupclient
 		// clang-format on
 	}
 
+	Sdp::RemoteSdp::~RemoteSdp()
+	{
+		MSC_TRACE();
+		for (const auto* mediaSection : this->mediaSections)
+		{
+			delete mediaSection;
+		}
+	}
+
 	void Sdp::RemoteSdp::UpdateIceParameters(const json& iceParameters)
 	{
 		MSC_TRACE();

--- a/src/sdp/RemoteSdp.cpp
+++ b/src/sdp/RemoteSdp.cpp
@@ -79,6 +79,7 @@ namespace mediasoupclient
 	Sdp::RemoteSdp::~RemoteSdp()
 	{
 		MSC_TRACE();
+		
 		for (const auto* mediaSection : this->mediaSections)
 		{
 			delete mediaSection;


### PR DESCRIPTION
The std::vector won’t delete the objects that are pointed to.