### PR TITLE
Convert RecvTransport::Listener to a subclass to avoid ambiguous conversion issues when the listener also implements the SendTransport::Listener interface.

### DIFF
--- a/include/Transport.hpp
+++ b/include/Transport.hpp
@@ -172,6 +172,12 @@ namespace mediasoupclient
 	                      public Consumer::PrivateListener,
 	                      public DataConsumer::PrivateListener
 	{
+	public:
+		/* Public Listener API */
+		class Listener : public Transport::Listener {
+
+		};
+
 	private:
 		RecvTransport(
 		  Listener* listener,
@@ -188,8 +194,6 @@ namespace mediasoupclient
 		friend Device;
 
 	public:
-		using Listener = Transport::Listener;
-
 		Consumer* Consume(
 		  Consumer::Listener* consumerListener,
 		  const std::string& id,

--- a/src/Device.cpp
+++ b/src/Device.cpp
@@ -170,7 +170,7 @@ namespace mediasoupclient
 	}
 
 	RecvTransport* Device::CreateRecvTransport(
-	  Transport::Listener* listener,
+	  RecvTransport::Listener* listener,
 	  const std::string& id,
 	  const json& iceParameters,
 	  const json& iceCandidates,
@@ -210,7 +210,7 @@ namespace mediasoupclient
 	}
 
 	RecvTransport* Device::CreateRecvTransport(
-	  Transport::Listener* listener,
+	  RecvTransport::Listener* listener,
 	  const std::string& id,
 	  const json& iceParameters,
 	  const json& iceCandidates,


### PR DESCRIPTION
When I implement a class that implements both SendTransport::Listener and RecvTransport::Listener (aka Transport::Listener), I can't pass it to Device::CreateRecvTransport because I get the following error:

```
Client.cpp:310:102: error: ambiguous conversion from derived class 'Client' to base class 'RecvTransport::Listener' (aka 'mediasoupclient::Transport::Listener'):
    class Client -> mediasoupclient::class SendTransport::Listener -> class Transport::Listener
    class Client -> mediasoupclient::class RecvTransport::Listener
            if (receive) internalState->receiveTransport = internalState->device.CreateRecvTransport(this, ...);
```

I can work around this by casting to Transport::Listener, but this would break compatibility with newer versions should RecvTransport::Listener ever need to be created in order to add interface methods to it. This patch converts RecvTransport::Listener to an empty Transport::Listener subclass, which resolves the error without breaking any pre-existing code.

Let me know if you'd like me to go a different route / make any changes.

Max