### PR TITLE
Fix ambiguous cast error when compiling with MSVC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 3.1.4 (WIP)
 
 * Convert RecvTransport::Listener to a subclass. Thanks @maxweisel.
+* Fix ambiguous cast error when compiling with MSVC. Thanks @maxweisel.
 
 ### 3.1.3
 

--- a/src/Handler.cpp
+++ b/src/Handler.cpp
@@ -100,7 +100,7 @@ namespace mediasoupclient
 		{
 			webrtc::PeerConnectionInterface::IceServer iceServer;
 
-			iceServer.uri = iceServerUri;
+			iceServer.uri = iceServerUri.get<std::string>();
 			configuration.servers.push_back(iceServer);
 		}
 


### PR DESCRIPTION
MSVC doesn't understand the implicit cast from json -> std::string, this uses the .get<std::string>() operator to make it explicit.