### PR TITLE
Fixed errors caused by DataProducer not initializing the 'closed' var…

### DIFF
--- a/include/DataProducer.hpp
+++ b/include/DataProducer.hpp
@@ -36,7 +36,7 @@ namespace mediasoupclient
 		Listener* listener;
 		std::string id;
 		rtc::scoped_refptr<webrtc::DataChannelInterface> dataChannel;
-		bool closed;
+		bool closed{ false };
 		nlohmann::json sctpStreamParameters;
 		nlohmann::json appData;
 		void TransportClosed();


### PR DESCRIPTION
failed with "mediasoupclient.test.cpp[line:301]:   REQUIRE(!dataProducer->IsClosed());"