### PR TITLE
Closing peer connection threads

### DIFF
--- a/include/Handler.hpp
+++ b/include/Handler.hpp
@@ -59,6 +59,7 @@ namespace mediasoupclient
 
 		/* Methods inherited from PeerConnectionListener. */
 	public:
+		void OnSignalingChange(webrtc::PeerConnectionInterface::SignalingState newState) override;
 		void OnIceConnectionChange(webrtc::PeerConnectionInterface::IceConnectionState newState) override;
 
 	protected:

--- a/include/PeerConnection.hpp
+++ b/include/PeerConnection.hpp
@@ -112,6 +112,7 @@ namespace mediasoupclient
 		~PeerConnection() = default;
 
 		void Close();
+		void CloseThreads();
 		webrtc::PeerConnectionInterface::RTCConfiguration GetConfiguration() const;
 		bool SetConfiguration(const webrtc::PeerConnectionInterface::RTCConfiguration& config);
 		std::string CreateOffer(const webrtc::PeerConnectionInterface::RTCOfferAnswerOptions& options);
@@ -135,9 +136,9 @@ namespace mediasoupclient
 
 	private:
 		// Signaling and worker threads.
-		std::unique_ptr<rtc::Thread> networkThread;
-		std::unique_ptr<rtc::Thread> signalingThread;
-		std::unique_ptr<rtc::Thread> workerThread;
+		std::unique_ptr<rtc::Thread> networkThread{ nullptr };
+		std::unique_ptr<rtc::Thread> signalingThread{ nullptr };
+		std::unique_ptr<rtc::Thread> workerThread{ nullptr };
 
 		// PeerConnection factory.
 		rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> peerConnectionFactory;

--- a/src/Handler.cpp
+++ b/src/Handler.cpp
@@ -110,6 +110,14 @@ namespace mediasoupclient
 		MSC_THROW_ERROR("failed to update ICE servers");
 	};
 
+	void Handler::OnSignalingChange(webrtc::PeerConnectionInterface::SignalingState newState)
+	{
+		MSC_TRACE();
+
+		if (newState == webrtc::PeerConnectionInterface::SignalingState::kClosed)
+			this->pc->CloseThreads();
+	}
+
 	void Handler::OnIceConnectionChange(webrtc::PeerConnectionInterface::IceConnectionState newState)
 	{
 		MSC_TRACE();

--- a/src/PeerConnection.cpp
+++ b/src/PeerConnection.cpp
@@ -118,6 +118,20 @@ namespace mediasoupclient
 		this->pc->Close();
 	}
 
+	void PeerConnection::CloseThreads()
+	{
+		MSC_TRACE();
+
+		if (this->networkThread != nullptr)
+			this->networkThread->Quit();
+
+		if (this->signalingThread != nullptr)
+			this->signalingThread->Quit();
+
+		if (this->workerThread != nullptr)
+			this->workerThread->Quit();
+	}
+
 	webrtc::PeerConnectionInterface::RTCConfiguration PeerConnection::GetConfiguration() const
 	{
 		MSC_TRACE();


### PR DESCRIPTION
When creating a new PeerConnection without a PeerConnectionFactory, network, signaling and worker threads are created.
After closing the peer connection, Handler will close those threads if they exist after receiving the OnSignalingChange for "close" state.