### PR TITLE
Issue 126

### DIFF
--- a/include/Handler.hpp
+++ b/include/Handler.hpp
@@ -29,7 +29,6 @@ namespace mediasoupclient
 	public:
 		struct DataChannel
 		{
-			std::string localId;
 			rtc::scoped_refptr<webrtc::DataChannelInterface> dataChannel;
 			nlohmann::json sctpStreamParameters;
 		};

--- a/include/Handler.hpp
+++ b/include/Handler.hpp
@@ -73,6 +73,7 @@ namespace mediasoupclient
 		// PeerConnection instance.
 		std::unique_ptr<PeerConnection> pc{ nullptr };
 		bool hasDataChannelMediaSection = false;
+		uint32_t nextSendSctpStreamId   = 0;
 	};
 
 	class SendHandler : public Handler

--- a/include/Handler.hpp
+++ b/include/Handler.hpp
@@ -73,7 +73,6 @@ namespace mediasoupclient
 		// PeerConnection instance.
 		std::unique_ptr<PeerConnection> pc{ nullptr };
 		bool hasDataChannelMediaSection = false;
-		uint32_t nextSendSctpStreamId   = 0;
 	};
 
 	class SendHandler : public Handler

--- a/include/Transport.hpp
+++ b/include/Transport.hpp
@@ -136,7 +136,6 @@ namespace mediasoupclient
 
 		DataProducer* ProduceData(
 		  DataProducer::Listener* listener,
-		  const uint16_t streamId       = 0,
 		  const std::string& label      = "",
 		  const std::string& protocol   = "",
 		  bool ordered                  = true,

--- a/include/Transport.hpp
+++ b/include/Transport.hpp
@@ -136,6 +136,7 @@ namespace mediasoupclient
 
 		DataProducer* ProduceData(
 		  DataProducer::Listener* listener,
+		  const uint16_t streamId       = 0,
 		  const std::string& label      = "",
 		  const std::string& protocol   = "",
 		  bool ordered                  = true,
@@ -206,6 +207,7 @@ namespace mediasoupclient
 		  DataConsumer::Listener* listener,
 		  const std::string& id,
 		  const std::string& producerId,
+		  const uint16_t streamId,
 		  const std::string& label,
 		  const std::string& protocol   = std::string(),
 		  const nlohmann::json& appData = nlohmann::json::object());

--- a/src/Handler.cpp
+++ b/src/Handler.cpp
@@ -315,15 +315,12 @@ namespace mediasoupclient
 	{
 		MSC_TRACE();
 
-		uint16_t streamId = this->nextSendSctpStreamId;
-
 		dataChannelInit.negotiated = true;
-		dataChannelInit.id         = streamId;
 
 		/* clang-format off */
 		json sctpStreamParameters =
 		{
-			{ "streamId", streamId                  },
+			{ "streamId", dataChannelInit.id        },
 			{ "ordered",  dataChannelInit.ordered   },
 			{ "protocol", dataChannelInit.protocol  }
 		};
@@ -344,9 +341,6 @@ namespace mediasoupclient
 
 		rtc::scoped_refptr<webrtc::DataChannelInterface> webrtcDataChannel =
 		  this->pc->CreateDataChannel(label, &dataChannelInit);
-
-		// Increase next id.
-		this->nextSendSctpStreamId = (this->nextSendSctpStreamId + 1) % SctpNumStreamsMis;
 
 		// If this is the first DataChannel we need to create the SDP answer with
 		// m=application section.
@@ -388,7 +382,6 @@ namespace mediasoupclient
 
 		SendHandler::DataChannel dataChannel;
 
-		dataChannel.localId              = std::to_string(streamId);
 		dataChannel.dataChannel          = webrtcDataChannel;
 		dataChannel.sctpStreamParameters = sctpStreamParameters;
 
@@ -660,15 +653,12 @@ namespace mediasoupclient
 	{
 		MSC_TRACE();
 
-		uint16_t streamId = this->nextSendSctpStreamId;
-
 		dataChannelInit.negotiated = true;
-		dataChannelInit.id         = streamId;
 
 		/* clang-format off */
 		nlohmann::json sctpStreamParameters =
 		{
-			{ "streamId", streamId                },
+			{ "streamId", dataChannelInit.id },
 			{ "ordered",  dataChannelInit.ordered }
 		};
 		/* clang-format on */
@@ -678,9 +668,6 @@ namespace mediasoupclient
 
 		rtc::scoped_refptr<webrtc::DataChannelInterface> webrtcDataChannel =
 		  this->pc->CreateDataChannel(label, &dataChannelInit);
-
-		// Increase next id.
-		this->nextSendSctpStreamId = (this->nextSendSctpStreamId + 1) % SctpNumStreamsMis;
 
 		// If this is the first DataChannel we need to create the SDP answer with
 		// m=application section.
@@ -713,7 +700,6 @@ namespace mediasoupclient
 
 		RecvHandler::DataChannel dataChannel;
 
-		dataChannel.localId              = std::to_string(streamId);
 		dataChannel.dataChannel          = webrtcDataChannel;
 		dataChannel.sctpStreamParameters = sctpStreamParameters;
 

--- a/src/Handler.cpp
+++ b/src/Handler.cpp
@@ -315,12 +315,15 @@ namespace mediasoupclient
 	{
 		MSC_TRACE();
 
+		uint16_t streamId = this->nextSendSctpStreamId;
+
 		dataChannelInit.negotiated = true;
+		dataChannelInit.id         = streamId;
 
 		/* clang-format off */
 		json sctpStreamParameters =
 		{
-			{ "streamId", dataChannelInit.id        },
+			{ "streamId", streamId                  },
 			{ "ordered",  dataChannelInit.ordered   },
 			{ "protocol", dataChannelInit.protocol  }
 		};
@@ -341,6 +344,9 @@ namespace mediasoupclient
 
 		rtc::scoped_refptr<webrtc::DataChannelInterface> webrtcDataChannel =
 		  this->pc->CreateDataChannel(label, &dataChannelInit);
+
+		// Increase next id.
+		this->nextSendSctpStreamId = (this->nextSendSctpStreamId + 1) % SctpNumStreamsMis;
 
 		// If this is the first DataChannel we need to create the SDP answer with
 		// m=application section.
@@ -382,6 +388,7 @@ namespace mediasoupclient
 
 		SendHandler::DataChannel dataChannel;
 
+		dataChannel.localId              = std::to_string(streamId);
 		dataChannel.dataChannel          = webrtcDataChannel;
 		dataChannel.sctpStreamParameters = sctpStreamParameters;
 

--- a/src/Handler.cpp
+++ b/src/Handler.cpp
@@ -388,7 +388,6 @@ namespace mediasoupclient
 
 		SendHandler::DataChannel dataChannel;
 
-		dataChannel.localId              = std::to_string(streamId);
 		dataChannel.dataChannel          = webrtcDataChannel;
 		dataChannel.sctpStreamParameters = sctpStreamParameters;
 

--- a/src/Transport.cpp
+++ b/src/Transport.cpp
@@ -250,6 +250,7 @@ namespace mediasoupclient
 
 	DataProducer* SendTransport::ProduceData(
 	  DataProducer::Listener* dataProducerListener,
+	  const uint16_t streamId,
 	  const std::string& label,
 	  const std::string& protocol,
 	  bool ordered,
@@ -263,6 +264,7 @@ namespace mediasoupclient
 			MSC_THROW_ERROR("SctpParameters are mandatory when using data producer listener");
 
 		webrtc::DataChannelInit dataChannelInit;
+		dataChannelInit.id       = streamId;
 		dataChannelInit.protocol = protocol;
 		dataChannelInit.ordered  = ordered;
 		if (maxRetransmits != -1 && maxPacketLifeTime != 0)
@@ -473,6 +475,7 @@ namespace mediasoupclient
 	  DataConsumer::Listener* listener,
 	  const std::string& id,
 	  const std::string& producerId,
+	  const uint16_t streamId,
 	  const std::string& label,
 	  const std::string& protocol,
 	  const nlohmann::json& appData)
@@ -481,6 +484,7 @@ namespace mediasoupclient
 
 		webrtc::DataChannelInit dataChannelInit;
 		dataChannelInit.protocol = protocol;
+		dataChannelInit.id       = streamId;
 
 		if (this->closed)
 			MSC_THROW_INVALID_STATE_ERROR("RecvTransport closed");

--- a/src/Transport.cpp
+++ b/src/Transport.cpp
@@ -250,7 +250,6 @@ namespace mediasoupclient
 
 	DataProducer* SendTransport::ProduceData(
 	  DataProducer::Listener* dataProducerListener,
-	  const uint16_t streamId,
 	  const std::string& label,
 	  const std::string& protocol,
 	  bool ordered,
@@ -264,7 +263,6 @@ namespace mediasoupclient
 			MSC_THROW_ERROR("SctpParameters are mandatory when using data producer listener");
 
 		webrtc::DataChannelInit dataChannelInit;
-		dataChannelInit.id       = streamId;
 		dataChannelInit.protocol = protocol;
 		dataChannelInit.ordered  = ordered;
 		if (maxRetransmits != -1 && maxPacketLifeTime != 0)

--- a/test/src/mediasoupclient.test.cpp
+++ b/test/src/mediasoupclient.test.cpp
@@ -285,7 +285,7 @@ TEST_CASE("mediasoupclient", "[mediasoupclient]")
 		/* clang-format on */
 
 		REQUIRE_NOTHROW(dataProducer.reset(
-		  sendTransport->ProduceData(&producerListener, 0, "", "", true, 0, 0, appData)));
+		  sendTransport->ProduceData(&producerListener, "", "", true, 0, 0, appData)));
 
 		REQUIRE(
 		  sendTransportListener.onConnectTimesCalled ==
@@ -327,7 +327,7 @@ TEST_CASE("mediasoupclient", "[mediasoupclient]")
 		  appData)));
 
 		REQUIRE_THROWS_AS(
-		  sendTransportNoSctp->ProduceData(&producerListener, 0, "", "", true, 0, 0, appData),
+		  sendTransportNoSctp->ProduceData(&producerListener, "", "", true, 0, 0, appData),
 		  MediaSoupClientError);
 	}
 

--- a/test/src/mediasoupclient.test.cpp
+++ b/test/src/mediasoupclient.test.cpp
@@ -285,7 +285,7 @@ TEST_CASE("mediasoupclient", "[mediasoupclient]")
 		/* clang-format on */
 
 		REQUIRE_NOTHROW(dataProducer.reset(
-		  sendTransport->ProduceData(&producerListener, "", "", true, 0, 0, appData)));
+		  sendTransport->ProduceData(&producerListener, 0, "", "", true, 0, 0, appData)));
 
 		REQUIRE(
 		  sendTransportListener.onConnectTimesCalled ==
@@ -327,7 +327,7 @@ TEST_CASE("mediasoupclient", "[mediasoupclient]")
 		  appData)));
 
 		REQUIRE_THROWS_AS(
-		  sendTransportNoSctp->ProduceData(&producerListener, "", "", true, 0, 0, appData),
+		  sendTransportNoSctp->ProduceData(&producerListener, 0, "", "", true, 0, 0, appData),
 		  MediaSoupClientError);
 	}
 


### PR DESCRIPTION
Fixes #126

Do not auto-generate the stream ID for the receiving dataChannel, but provide it via API.

Bonus: Remove the unused `localId` member from `DataChannel`.

NOTE: This PR does not aim to modify how the arguments are provided to the API methods: JSON objects vs spare arguments.

- [x] Update the docs
- [x] Update Broadcaster demo
- [x] Update mediasoup-demo 