### PR TITLE
fix(build): min() and max() conflict on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,10 @@ add_subdirectory(deps/libsdptransform "${CMAKE_CURRENT_BINARY_DIR}/libsdptransfo
 if(MSVC)
 	set_source_files_properties(${SOURCE_FILES}
 		PROPERTIES COMPILE_FLAGS "/W3 /WX")
+	target_compile_definitions(${PROJECT_NAME}
+		PRIVATE 
+		NOMINMAX
+	)
 else()
 	set_source_files_properties(${SOURCE_FILES}
 		PROPERTIES COMPILE_FLAGS -Wall -Wextra -Wpedantic)


### PR DESCRIPTION
std::min() and std::max() is conflict with macro min() and max() in windows.h when use namespace std.

According to this link [winrtc](https://docs.microsoft.com/en-us/winrtc/getting-started#consuming-the-generated-binaries), We may add some preprocessor definitions on windows.

Add macro NOMINMAX can pass build solve this conflict.