### PR TITLE
Fix to build on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
-**/build/
-**/node_modules/
-test/libwebrtc/
-**/.vs/
+/build/
+/node_modules/
 
 compile_commands.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-/build/
-/node_modules/
+**/build/
+**/node_modules/
+test/libwebrtc/
+**/.vs/
 
 compile_commands.json
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,14 +112,6 @@ add_subdirectory(deps/libsdptransform "${CMAKE_CURRENT_BINARY_DIR}/libsdptransfo
 if(MSVC)
 	set_source_files_properties(${SOURCE_FILES}
 		PROPERTIES COMPILE_FLAGS "/W3")
-	target_link_libraries(${PROJECT_NAME} PRIVATE
-		winmm
-		Secur32
-		wmcodecdspuuid
-		msdmo
-		dmoguids
-		Strmiids
-	)
 else()
 	set_source_files_properties(${SOURCE_FILES}
 		PROPERTIES COMPILE_FLAGS -Wall -Wextra -Wpedantic)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,15 @@ add_subdirectory(deps/libsdptransform "${CMAKE_CURRENT_BINARY_DIR}/libsdptransfo
 # Add some compile flags to our source files.
 if(MSVC)
 	set_source_files_properties(${SOURCE_FILES}
-		PROPERTIES COMPILE_FLAGS "/W3 /WX")
+		PROPERTIES COMPILE_FLAGS "/W3")
+	target_link_libraries(${PROJECT_NAME} PRIVATE
+		winmm
+		Secur32
+		wmcodecdspuuid
+		msdmo
+		dmoguids
+		Strmiids
+	)
 else()
 	set_source_files_properties(${SOURCE_FILES}
 		PROPERTIES COMPILE_FLAGS -Wall -Wextra -Wpedantic)
@@ -137,6 +145,8 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
 target_compile_definitions(${PROJECT_NAME} PUBLIC
 	$<$<NOT:$<PLATFORM_ID:Windows>>:WEBRTC_POSIX>
 	$<$<PLATFORM_ID:Windows>:WEBRTC_WIN>
+	$<$<PLATFORM_ID:Windows>:NOMINMAX>
+	$<$<PLATFORM_ID:Windows>:WIN32_LEAN_AND_MEAN>
 	$<$<PLATFORM_ID:Darwin>:WEBRTC_MAC>
 )
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,6 +52,11 @@ if(UNIX)
 	target_link_libraries(test_mediasoupclient PRIVATE Threads::Threads)
 endif(UNIX)
 
+target_compile_definitions(test_mediasoupclient PUBLIC
+	$<$<PLATFORM_ID:Windows>:NOMINMAX>
+	$<$<PLATFORM_ID:Windows>:WIN32_LEAN_AND_MEAN>
+)
+
 # Private dependencies.
 target_link_libraries(test_mediasoupclient PRIVATE mediasoupclient)
 target_link_libraries(test_mediasoupclient PRIVATE ${CMAKE_DL_LIBS})

--- a/test/deps/libwebrtc/CMakeLists.txt
+++ b/test/deps/libwebrtc/CMakeLists.txt
@@ -18,6 +18,8 @@ target_include_directories(webrtc PUBLIC
 target_compile_definitions(webrtc PUBLIC
 	$<$<NOT:$<PLATFORM_ID:Windows>>:WEBRTC_POSIX>
 	$<$<PLATFORM_ID:Windows>:WEBRTC_WIN>
+	$<$<PLATFORM_ID:Windows>:NOMINMAX>
+	$<$<PLATFORM_ID:Windows>:WIN32_LEAN_AND_MEAN>
 	$<$<PLATFORM_ID:Darwin>:WEBRTC_MAC>
 )
 


### PR DESCRIPTION
A few small changes that enable **libmediasoupclient** to build on Windows out of the box. Similar to #135 but also updated the unit tests and added the `WIN32_MEAN_AND_LEAN` flag to reduce possible overhead (Thanks to #43).  Also, since clang must be used to build WebRTC rather than MSVC, H264 should still work.

Unfortunately the unit tests still don't build on Windows, and the compiler instead complains about `RTC_NOTREACHED()` not being defined.  If someone knows what the function is used for and which header its in, that would be very useful

I'll submit a PR to the website docs to provide examples of building on Windows, but here's a quick rundown of what to do:
To build **libmediasoupclient** on Windows, WebRTC must be built with VS2019 or higher, and these gn args: `is_clang=true use_custom_libcxx=false`. If an application that consumes **libmediasoupclient** is built in Debug mode, it must link to WebRTC that was built with `enable_iterator_debugging=true` and possibly `is_debug=true`. Optionally, set `rtc_use_h264=true` to enable support for H264 codec

Afterwards, simply follow the [build guide](https://mediasoup.org/documentation/v3/libmediasoupclient/installation/) for **libmediasoupclient**, but instead of running `make`, go to `/build`, open the VS solution, and build `ALL_BUILD`. Once finished building, `mediasoupclient.lib` will be located in either the `Debug` or `Release` folder, depending on how you built it.