### PR TITLE
Add cbr config option for opus

### DIFF
--- a/src/ortc.cpp
+++ b/src/ortc.cpp
@@ -917,10 +917,10 @@ namespace mediasoupclient
 			auto opusStereoIt              = params.find("opusStereo");
 			auto opusFecIt                 = params.find("opusFec");
 			auto opusDtxIt                 = params.find("opusDtx");
+			auto opusCbrIt                 = params.find("opusCbr");
 			auto opusMaxPlaybackRateIt     = params.find("opusMaxPlaybackRate");
 			auto opusMaxAverageBitrateIt   = params.find("opusMaxAverageBitrate");
 			auto opusPtimeIt               = params.find("opusPtime");
-			auto opusCbrIt                 = params.find("opusCbr");
 			auto videoGoogleStartBitrateIt = params.find("videoGoogleStartBitrate");
 			auto videoGoogleMaxBitrateIt   = params.find("videoGoogleMaxBitrate");
 			auto videoGoogleMinBitrateIt   = params.find("videoGoogleMinBitrate");
@@ -940,22 +940,24 @@ namespace mediasoupclient
 				MSC_THROW_TYPE_ERROR("invalid params.opusDtx");
 			}
 
+			if (opusCbrIt != params.end() && !opusCbrIt->is_boolean())
+			{
+				MSC_THROW_TYPE_ERROR("invalid params.opusCbr");
+			}
+
 			if (opusMaxPlaybackRateIt != params.end() && !opusMaxPlaybackRateIt->is_number_unsigned())
 			{
 				MSC_THROW_TYPE_ERROR("invalid params.opusMaxPlaybackRate");
 			}
+
 			if (opusMaxAverageBitrateIt != params.end() && !opusMaxAverageBitrateIt->is_number_unsigned())
 			{
 				MSC_THROW_TYPE_ERROR("invalid params.opusMaxAverageBitrate");
 			}
+
 			if (opusPtimeIt != params.end() && !opusPtimeIt->is_number_integer())
 			{
 				MSC_THROW_TYPE_ERROR("invalid params.opusPtime");
-			}
-
-			if (opusCbrIt != params.end() && !opusCbrIt->is_boolean())
-			{
-				MSC_THROW_TYPE_ERROR("invalid params.opusCbr");
 			}
 
 			if (videoGoogleStartBitrateIt != params.end() && !videoGoogleStartBitrateIt->is_number_integer())

--- a/src/ortc.cpp
+++ b/src/ortc.cpp
@@ -920,6 +920,7 @@ namespace mediasoupclient
 			auto opusMaxPlaybackRateIt     = params.find("opusMaxPlaybackRate");
 			auto opusMaxAverageBitrateIt   = params.find("opusMaxAverageBitrate");
 			auto opusPtimeIt               = params.find("opusPtime");
+			auto opusCbrIt                 = params.find("opusCbr");
 			auto videoGoogleStartBitrateIt = params.find("videoGoogleStartBitrate");
 			auto videoGoogleMaxBitrateIt   = params.find("videoGoogleMaxBitrate");
 			auto videoGoogleMinBitrateIt   = params.find("videoGoogleMinBitrate");
@@ -950,6 +951,11 @@ namespace mediasoupclient
 			if (opusPtimeIt != params.end() && !opusPtimeIt->is_number_integer())
 			{
 				MSC_THROW_TYPE_ERROR("invalid params.opusPtime");
+			}
+
+			if (opusCbrIt != params.end() && !opusCbrIt->is_boolean())
+			{
+				MSC_THROW_TYPE_ERROR("invalid params.opusCbr");
 			}
 
 			if (videoGoogleStartBitrateIt != params.end() && !videoGoogleStartBitrateIt->is_number_integer())

--- a/src/sdp/MediaSection.cpp
+++ b/src/sdp/MediaSection.cpp
@@ -227,6 +227,14 @@ namespace mediasoupclient
 								auto opusPtime           = opusPtimeIt->get<uint32_t>();
 								codecParameters["ptime"] = opusPtime;
 							}
+
+							auto opusCbrIt = codecOptions->find("opusCbr");
+							if (opusCbrIt != codecOptions->end())
+							{
+								auto opusCbr                    = opusCbrIt->get<bool>();
+								offerCodec["parameters"]["cbr"] = opusCbr ? 1 : 0;
+								codecParameters["cbr"]          = opusCbr ? 1 : 0;
+							}
 						}
 						else if (mimeType == "video/vp8" || mimeType == "video/vp9" || mimeType == "video/h264" || mimeType == "video/h265")
 						{

--- a/src/sdp/MediaSection.cpp
+++ b/src/sdp/MediaSection.cpp
@@ -207,6 +207,14 @@ namespace mediasoupclient
 								codecParameters["usedtx"]          = opusDtx ? 1 : 0;
 							}
 
+							auto opusCbrIt = codecOptions->find("opusCbr");
+							if (opusCbrIt != codecOptions->end())
+							{
+								auto opusCbr                    = opusCbrIt->get<bool>();
+								offerCodec["parameters"]["cbr"] = opusCbr ? 1 : 0;
+								codecParameters["cbr"]          = opusCbr ? 1 : 0;
+							}
+
 							auto opusMaxPlaybackRateIt = codecOptions->find("opusMaxPlaybackRate");
 							if (opusMaxPlaybackRateIt != codecOptions->end())
 							{
@@ -226,14 +234,6 @@ namespace mediasoupclient
 							{
 								auto opusPtime           = opusPtimeIt->get<uint32_t>();
 								codecParameters["ptime"] = opusPtime;
-							}
-
-							auto opusCbrIt = codecOptions->find("opusCbr");
-							if (opusCbrIt != codecOptions->end())
-							{
-								auto opusCbr                    = opusCbrIt->get<bool>();
-								offerCodec["parameters"]["cbr"] = opusCbr ? 1 : 0;
-								codecParameters["cbr"]          = opusCbr ? 1 : 0;
 							}
 						}
 						else if (mimeType == "video/vp8" || mimeType == "video/vp9" || mimeType == "video/h264" || mimeType == "video/h265")


### PR DESCRIPTION
Setup wiring to accept `opusCbr` for configuring opus. 