### PR TITLE
Move SetRemoteDescription to Recommended API

### DIFF
--- a/include/PeerConnection.hpp
+++ b/include/PeerConnection.hpp
@@ -87,16 +87,16 @@ namespace mediasoupclient
     class SetRemoteDescriptionObserver : public webrtc::SetRemoteDescriptionObserverInterface {
     public:
       // Default constructor.
-      SetRemoteDescriptionObserver() = default
-      ~SetRemoteDescriptionObserver() override = default
+      SetRemoteDescriptionObserver() = default;
+      ~SetRemoteDescriptionObserver() override = default;
 
-      std::future<std::string> GetFuture();
+      std::future<void> GetFuture();
       void Reject(const std::string& error);
 
-      void OnSetRemoteDescriptionComplete(RTCError error);
+      void OnSetRemoteDescriptionComplete(webrtc::RTCError error);
 
 		private:
-			std::promise<std::string> promise;
+			std::promise<void> promise;
     };
 
 		class RTCStatsCollectorCallback : public webrtc::RTCStatsCollectorCallback

--- a/include/PeerConnection.hpp
+++ b/include/PeerConnection.hpp
@@ -84,6 +84,21 @@ namespace mediasoupclient
 			std::promise<std::string> promise;
 		};
 
+    class SetRemoteDescriptionObserver : public webrtc::SetRemoteDescriptionObserverInterface {
+    public:
+      // Default constructor.
+      SetRemoteDescriptionObserver() = default
+      ~SetRemoteDescriptionObserver() override = default
+
+      std::future<std::string> GetFuture();
+      void Reject(const std::string& error);
+
+      void OnSetRemoteDescriptionComplete(RTCError error);
+
+		private:
+			std::promise<std::string> promise;
+    };
+
 		class RTCStatsCollectorCallback : public webrtc::RTCStatsCollectorCallback
 		{
 		public:
@@ -145,6 +160,8 @@ namespace mediasoupclient
 		// PeerConnection instance.
 		rtc::scoped_refptr<webrtc::PeerConnectionInterface> pc;
 	};
+
+
 } // namespace mediasoupclient
 
 #endif

--- a/src/PeerConnection.cpp
+++ b/src/PeerConnection.cpp
@@ -211,17 +211,14 @@ namespace mediasoupclient
 		webrtc::SdpParseError error;
 		std::unique_ptr<webrtc::SessionDescriptionInterface> sessionDescription;
 		rtc::scoped_refptr<SetRemoteDescriptionObserver> observer = new rtc::RefCountedObject<SetRemoteDescriptionObserver>();
-		  // rtc::scoped_refptr<SetSessionDescriptionObserver>
-		  //   observer(new rtc::RefCountedObject<SetSessionDescriptionObserver>());
 
 		const auto& typeStr = sdpType2String[type];
 		auto future         = observer->GetFuture();
 
-		//sessionDescription = std::unique_ptr<webrtc::SessionDescriptionInterface>(webrtc::CreateSessionDescription(typeStr, sdp, &error));
 
 		std::unique_ptr<webrtc::SessionDescriptionInterface> ownedDesc(webrtc::CreateSessionDescription(typeStr, sdp, &error));
 
-		if (sessionDescription == nullptr)
+		if (ownedDesc == nullptr)
 		{
 			MSC_WARN(
 			  "webrtc::CreateSessionDescription failed [%s]: %s",

--- a/src/PeerConnection.cpp
+++ b/src/PeerConnection.cpp
@@ -209,7 +209,6 @@ namespace mediasoupclient
 		MSC_TRACE();
 
 		webrtc::SdpParseError error;
-		std::unique_ptr<webrtc::SessionDescriptionInterface> sessionDescription;
 		rtc::scoped_refptr<SetRemoteDescriptionObserver> observer = new rtc::RefCountedObject<SetRemoteDescriptionObserver>();
 
 		const auto& typeStr = sdpType2String[type];


### PR DESCRIPTION
HI, 

In production we've observer that calls to `SetRemoteDescription` can block indefinitely. Based on comments from the WebRTC m94 branch this can happen.  

```  
  file: api/peer_connection_interface.h
  // Sets the remote session description.
  //
  // (Unlike "SDP munging" before SetLocalDescription(), modifying a remote
  // offer or answer is allowed by the spec.)
  //
  // The observer is invoked as soon as the operation completes, which could be
  // before or after the SetRemoteDescription() method has exited.
  virtual void SetRemoteDescription(
      std::unique_ptr<SessionDescriptionInterface> desc,
      rtc::scoped_refptr<SetRemoteDescriptionObserverInterface> observer) = 0;
  // Like SetRemoteDescription() above, but the observer is invoked with a delay
  // after the operation completes. This helps avoid recursive calls by the
  // observer but also makes it possible for states to change in-between the
  // operation completing and the observer getting called. This makes them racy
  // for synchronizing peer connection states to the application.
  // TODO(https://crbug.com/webrtc/11798): Delete this method in favor of the
  // ones taking SetRemoteDescriptionObserverInterface as argument.
  virtual void SetRemoteDescription(SetSessionDescriptionObserver* observer,
                                    SessionDescriptionInterface* desc) {}
```

I've implemented the api using the `SetRemoteDescriptionObserverInterface`. Looking for feedback to this change. 