### PR TITLE
Use _SC_MINSIGSTKSZ instead of MINSIGSTKSZ

### DIFF
--- a/deps/libsdptransform/test/include/catch.hpp
+++ b/deps/libsdptransform/test/include/catch.hpp
@@ -10705,6 +10705,10 @@ PVOID FatalConditionHandler::exceptionHandlerHandle = nullptr;
 
 #elif defined( CATCH_CONFIG_POSIX_SIGNALS )
 
+#if defined( _SC_MINSIGSTKSZ )
+#define MINSIGSTKSZ _SC_MINSIGSTKSZ
+#endif
+
 namespace Catch {
 
     struct SignalDefs {


### PR DESCRIPTION
Because MINSIGSTKSZ is no longer constant after glibc 2.34.

https://sourceware.org/git/?p=glibc.git;a=blob;f=NEWS;h=85e84fe53699fe9e392edffa993612ce08b2954a;hb=HEAD

Fix: https://github.com/versatica/libmediasoupclient/issues/145