### PR TITLE
Change default return value of "getH264ProfileLevelId"

### DIFF
--- a/src/ortc.cpp
+++ b/src/ortc.cpp
@@ -1788,7 +1788,7 @@ static std::string getH264ProfileLevelId(const json& codec)
 	auto profileLevelIdIt  = parameters.find("profile-level-id");
 
 	if (profileLevelIdIt == parameters.end())
-		return "";
+		return "42e01f";
 	else if (profileLevelIdIt->is_number())
 		return std::to_string(profileLevelIdIt->get<int32_t>());
 	else


### PR DESCRIPTION
hello!

I suggest `getH264ProfileLevelId` behavior when profile-level-id is not found in H264 codec parameters.

Now, it  returns an empty string, so it will always not match when compared to codecs with a profile-level-id.

On the other hand, the H264 checker used in the JavaScript SDK returns an id of ConstrainedBaseline (Level3.1), which works differently from libmediasoupclient.
https://github.com/ibc/h264-profile-level-id/blob/8f2eee9ed846113a58b9f562947f45cd9d8f7cb9/index.js#L78

I think the JavaScript SDK is more available and should be used that way.

With this fix, I have confirmed that H264 communication with mobile devices is possible even if profile-level-id is not included in the codec parameters on the mediasoup server.