### PR TITLE
Handler: allow spatial layers from 0 to N

### DIFF
--- a/include/Producer.hpp
+++ b/include/Producer.hpp
@@ -87,7 +87,7 @@ namespace mediasoupclient
 		// Paused flag.
 		bool paused{ false };
 		// Video Max spatial layer.
-		uint8_t maxSpatialLayer{ 0 };
+		uint8_t maxSpatialLayer{ (uint8_t) -1 };
 		// App custom data.
 		nlohmann::json appData;
 	};

--- a/src/Handler.cpp
+++ b/src/Handler.cpp
@@ -516,51 +516,13 @@ namespace mediasoupclient
 		auto* transceiver = localIdIt->second;
 		auto parameters   = transceiver->sender()->GetParameters();
 
-		bool hasLowEncoding{ false };
-		bool hasMediumEncoding{ false };
-		bool hasHighEncoding{ false };
-		webrtc::RtpEncodingParameters* lowEncoding{ nullptr };
-		webrtc::RtpEncodingParameters* mediumEncoding{ nullptr };
-		webrtc::RtpEncodingParameters* highEncoding{ nullptr };
-
-		if (!parameters.encodings.empty())
+		// Edit encodings. Activate only the layers below or equal to spatialLayer.
+		if (!parameters.encodings.empty() && (spatialLayer < parameters.encodings.size()))
 		{
-			hasLowEncoding = true;
-			lowEncoding    = &parameters.encodings[0];
-		}
-
-		if (parameters.encodings.size() > 1)
-		{
-			hasMediumEncoding = true;
-			mediumEncoding    = &parameters.encodings[1];
-		}
-
-		if (parameters.encodings.size() > 2)
-		{
-			hasHighEncoding = true;
-			highEncoding    = &parameters.encodings[2];
-		}
-
-		// Edit encodings.
-		if (spatialLayer == 1u)
-		{
-			hasLowEncoding && (lowEncoding->active = true);
-			hasMediumEncoding && (mediumEncoding->active = false);
-			hasHighEncoding && (highEncoding->active = false);
-		}
-
-		else if (spatialLayer == 2u)
-		{
-			hasLowEncoding && (lowEncoding->active = true);
-			hasMediumEncoding && (mediumEncoding->active = true);
-			hasHighEncoding && (highEncoding->active = false);
-		}
-
-		else if (spatialLayer == 3u)
-		{
-			hasLowEncoding && (lowEncoding->active = true);
-			hasMediumEncoding && (mediumEncoding->active = true);
-			hasHighEncoding && (highEncoding->active = true);
+			for (int i = parameters.encodings.size() - 1; i >= 0; i--)
+			{
+				parameters.encodings[i].active = (i <= spatialLayer);
+			}
 		}
 
 		auto result = transceiver->sender()->SetParameters(parameters);

--- a/test/src/mediasoupclient.test.cpp
+++ b/test/src/mediasoupclient.test.cpp
@@ -211,7 +211,7 @@ TEST_CASE("mediasoupclient", "[mediasoupclient]")
 		REQUIRE(audioProducer->GetRtpSender() != nullptr);
 		REQUIRE(audioProducer->GetTrack() == audioTrack);
 		REQUIRE(audioProducer->IsPaused());
-		REQUIRE(audioProducer->GetMaxSpatialLayer() == 0);
+		REQUIRE(audioProducer->GetMaxSpatialLayer() == (uint8_t) -1);
 		REQUIRE(audioProducer->GetAppData() == appData);
 		REQUIRE(audioProducer->GetRtpParameters()["codecs"].size() == 1);
 


### PR DESCRIPTION
This fixes an incompatibility with mediasoup server which in v3 spatial layers go from 0 to N, however libmediasoupclient is still using v2 spatial layers.