### PR TITLE
Clear the stored transceivers before closing the PeerConnection

### DIFF
--- a/src/Handler.cpp
+++ b/src/Handler.cpp
@@ -85,6 +85,9 @@ namespace mediasoupclient
 	{
 		MSC_TRACE();
 
+		// clear the stored transceivers before closing the PeerConnection
+		this->mapMidTransceiver.clear();
+
 		this->pc->Close();
 	};
 

--- a/src/Handler.cpp
+++ b/src/Handler.cpp
@@ -85,7 +85,7 @@ namespace mediasoupclient
 	{
 		MSC_TRACE();
 
-		// clear the stored transceivers before closing the PeerConnection
+		// Clear the stored transceivers before closing the PeerConnection.
 		this->mapMidTransceiver.clear();
 
 		this->pc->Close();


### PR DESCRIPTION
During a `{Send|Recv}Transport` instance destruction, its `Handler` also gets destroyed.
The Handler stores a `PeerConnection` and a map of pointers to RTP transceivers.

When the transport gets closed, the PC gets closed but the transceivers are leaked.

On the `m112` branch the RTP transceiver map entries are now RTC smart pointers. This results in a fatal process hang during the destruction of the map and its entries, which occurs after the destruction of the `pc` instance variable.
RTPTransceiver destruction relies on waiting indefinitely for an event signaled by a thread which was owned by the now destroyed PC.

This fix simply clears the stored transceivers map before the PC is closed. This is sufficient (and necessary) for the `m112` branch, it does not address the current leaky behaviour.