### PR TITLE
Fix non-virtual destructors

### DIFF
--- a/include/Handler.hpp
+++ b/include/Handler.hpp
@@ -21,6 +21,7 @@ namespace mediasoupclient
 		class PrivateListener
 		{
 		public:
+			virtual ~PrivateListener() = default;
 			virtual void OnConnect(nlohmann::json& dtlsParameters) = 0;
 			virtual void OnConnectionStateChange(
 			  webrtc::PeerConnectionInterface::IceConnectionState connectionState) = 0;

--- a/include/Logger.hpp
+++ b/include/Logger.hpp
@@ -65,6 +65,7 @@ namespace mediasoupclient
 		class LogHandlerInterface
 		{
 		public:
+			virtual ~LogHandlerInterface() = default;
 			virtual void OnLog(LogLevel level, char* payload, size_t len) = 0;
 		};
 

--- a/include/Transport.hpp
+++ b/include/Transport.hpp
@@ -29,6 +29,7 @@ namespace mediasoupclient
 		class Listener
 		{
 		public:
+			virtual ~Listener() = default;
 			virtual std::future<void> OnConnect(Transport* transport, const nlohmann::json& dtlsParameters) = 0;
 			virtual void OnConnectionStateChange(Transport* transport, const std::string& connectionState) = 0;
 		};
@@ -42,6 +43,7 @@ namespace mediasoupclient
 		  const nlohmann::json& appData);
 
 	public:
+		virtual ~Transport() = default;
 		const std::string& GetId() const;
 		bool IsClosed() const;
 		const std::string& GetConnectionState() const;


### PR DESCRIPTION
This fixes compiler warnings when calling `delete` via base class pointers of classes without virtual destructors, e.g. when subclassing, the subclass destructor will not be called.
Warning is triggered even if simply `delete`-ing on the instance pointers returned by the API.

Environment: compiling with Android NDK r25c (older releases: same result), C++ 11/14/17.