### PR TITLE
Use explicit NEWLINE_STYLE for version.hpp

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.hpp text eol=lf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(mediasoupclient_VERSION_PATCH 0)
 configure_file (
 	"${PROJECT_SOURCE_DIR}/version.hpp.in"
 	"${PROJECT_SOURCE_DIR}/include/version.hpp"
+	NEWLINE_STYLE LF
 )
 
 # C++ standard requirements.


### PR DESCRIPTION
The file include/version.hpp is configured by CMake and also commited
to the repo.  CMake will generate this file with different line endings
depending on the platform, however, the file commited to the repo uses
LF line endings.  This PR modifies the CMake to always generates LF
line endings so its output always matches what has been commited to
the repo.

I've also added ".gitattributes" to make sure that git doesn't modify
the line endings of any ".hpp" depending on the users "core.autocrlf"
setting.  Without this, there would still be a discrepancy to address
depending on whether this setting is enabled.

Note that another option here would be to run `git config -get core.autocrlf` and change the `NEWLINE_STYLE` depending on the result, but, I opted to go with the simpler solution.