### PR TITLE
Fix UpdateIceServers method parameters format

### DIFF
--- a/src/Handler.cpp
+++ b/src/Handler.cpp
@@ -108,10 +108,23 @@ namespace mediasoupclient
 
 		for (const auto& iceServerDescription : iceServersDescription)
 		{
+			if (!iceServerDescription.contains("urls")) {
+				continue;
+			}
 			webrtc::PeerConnectionInterface::IceServer iceServer;
-			iceServer.urls = iceServerDescription.at("urls").get<std::vector<std::string>>();
-			iceServer.username = iceServerDescription.at("username").get<std::string>();
-			iceServer.password = iceServerDescription.at("credential").get<std::string>();
+			if (iceServerDescription["urls"].is_string()) {
+				iceServer.urls = { iceServerDescription["urls"].get<std::string>() };
+			} else if (iceServerDescription["urls"].is_array()) {
+				iceServer.urls = iceServerDescription["urls"].get<std::vector<std::string>>();
+			} else {
+				continue;
+			}
+			if (iceServerDescription.contains("username")) {
+				iceServer.username = iceServerDescription["username"].get<std::string>();
+			}
+			if (iceServerDescription.contains("credential")) {
+				iceServer.password = iceServerDescription["credential"].get<std::string>();
+			}
 			configuration.servers.push_back(iceServer);
 		}
 

--- a/src/Handler.cpp
+++ b/src/Handler.cpp
@@ -98,7 +98,7 @@ namespace mediasoupclient
 		return this->pc->GetStats();
 	}
 
-	void Handler::UpdateIceServers(const json& iceServerUris)
+	void Handler::UpdateIceServers(const json& iceServersDescription)
 	{
 		MSC_TRACE();
 
@@ -106,11 +106,12 @@ namespace mediasoupclient
 
 		configuration.servers.clear();
 
-		for (const auto& iceServerUri : iceServerUris)
+		for (const auto& iceServerDescription : iceServersDescription)
 		{
 			webrtc::PeerConnectionInterface::IceServer iceServer;
-
-			iceServer.uri = iceServerUri.get<std::string>();
+			iceServer.urls = iceServerDescription.at("urls").get<std::vector<std::string>>();
+			iceServer.username = iceServerDescription.at("username").get<std::string>();
+			iceServer.password = iceServerDescription.at("credential").get<std::string>();
 			configuration.servers.push_back(iceServer);
 		}
 

--- a/test/include/fakeParameters.hpp
+++ b/test/include/fakeParameters.hpp
@@ -11,5 +11,6 @@ json generateLocalDtlsParameters();
 json generateTransportRemoteParameters();
 std::string generateProducerRemoteId();
 json generateConsumerRemoteParameters(const std::string& codecMimeType);
+json generateIceServers();
 
 #endif

--- a/test/src/Handler.test.cpp
+++ b/test/src/Handler.test.cpp
@@ -8,6 +8,7 @@
 
 static const json TransportRemoteParameters = generateTransportRemoteParameters();
 static const json RtpParametersByKind       = generateRtpParametersByKind();
+static const json IceServers                = generateIceServers();
 
 static mediasoupclient::PeerConnection::Options PeerConnectionOptions;
 
@@ -201,8 +202,13 @@ TEST_CASE("RecvHandler", "[Handler][RecvHandler]")
 		REQUIRE_NOTHROW(recvHandler.RestartIce(iceParameters));
 	}
 
-	SECTION("recvHandler.UpdateIceServers() succeeds")
+	SECTION("recvHandler.UpdateIceServers() succeeds with empty array")
 	{
 		REQUIRE_NOTHROW(recvHandler.UpdateIceServers(json::array()));
+	}
+
+	SECTION("recvHandler.UpdateIceServers() succeeds with non-empty array")
+	{
+		REQUIRE_NOTHROW(recvHandler.UpdateIceServers(IceServers));
 	}
 }

--- a/test/src/fakeParameters.cpp
+++ b/test/src/fakeParameters.cpp
@@ -477,3 +477,22 @@ json generateConsumerRemoteParameters(const std::string& codecMimeType)
 
 	return json::object();
 };
+
+json generateIceServers()
+{
+	auto json = R"(
+	[
+		{
+			"urls"       : [
+				"turn:t1.server.com",
+				"turn:t2.server.com"
+			],
+			"username"   : "fakeuser",
+			"credential" : "fakepass"
+		},
+		{
+			"urls" : "stun:s.server.com"
+		}
+	])"_json;
+	return json;
+};


### PR DESCRIPTION
`iceServerUris` parameter parsing logic in [`UpdateIceServers` method](https://github.com/versatica/libmediasoupclient/blob/48768ba90dee235e045e8dfbf364365504e2c4ce/src/Handler.cpp#L113C20-L113C20) in its current state suggests that the parameter is an array of strings.

[Documentation](https://mediasoup.org/documentation/v3/libmediasoupclient/api/#Transport-UpdateIceServers) suggests that this parameter is an array of [RTCIceServer](https://w3c.github.io/webrtc-pc/#rtciceserver-dictionary) structures. TS implementation uses same structure as far as I can see.

I've had part of this changes in my fork for the last year, but now I've decided to make a PR, so I added relevant test case and made parsing logic more general to support everything documentation describes.