### PR TITLE
upgrade to webrtc m120-6099。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ compile_commands.json
 # Vim temporal files.
 *.swp
 *.swo
+deps
+.vscode

--- a/src/PeerConnection.cpp
+++ b/src/PeerConnection.cpp
@@ -11,6 +11,19 @@
 #include <api/video_codecs/builtin_video_encoder_factory.h>
 #include <rtc_base/ssl_adapter.h>
 
+#include "api/video_codecs/video_decoder_factory.h"
+#include "api/video_codecs/video_decoder_factory_template.h"
+#include "api/video_codecs/video_decoder_factory_template_dav1d_adapter.h"
+#include "api/video_codecs/video_decoder_factory_template_libvpx_vp8_adapter.h"
+#include "api/video_codecs/video_decoder_factory_template_libvpx_vp9_adapter.h"
+#include "api/video_codecs/video_decoder_factory_template_open_h264_adapter.h"
+#include "api/video_codecs/video_encoder_factory.h"
+#include "api/video_codecs/video_encoder_factory_template.h"
+#include "api/video_codecs/video_encoder_factory_template_libaom_av1_adapter.h"
+#include "api/video_codecs/video_encoder_factory_template_libvpx_vp8_adapter.h"
+#include "api/video_codecs/video_encoder_factory_template_libvpx_vp9_adapter.h"
+#include "api/video_codecs/video_encoder_factory_template_open_h264_adapter.h"
+
 using json = nlohmann::json;
 
 namespace mediasoupclient
@@ -99,8 +112,16 @@ namespace mediasoupclient
 			  nullptr /*default_adm*/,
 			  webrtc::CreateBuiltinAudioEncoderFactory(),
 			  webrtc::CreateBuiltinAudioDecoderFactory(),
-			  webrtc::CreateBuiltinVideoEncoderFactory(),
-			  webrtc::CreateBuiltinVideoDecoderFactory(),
+			  std::make_unique<webrtc::VideoEncoderFactoryTemplate<
+				webrtc::LibvpxVp8EncoderTemplateAdapter,
+				webrtc::LibvpxVp9EncoderTemplateAdapter,
+				webrtc::OpenH264EncoderTemplateAdapter,
+				webrtc::LibaomAv1EncoderTemplateAdapter>>(),
+			  std::make_unique<webrtc::VideoDecoderFactoryTemplate<
+				webrtc::LibvpxVp8DecoderTemplateAdapter,
+				webrtc::LibvpxVp9DecoderTemplateAdapter,
+				webrtc::OpenH264DecoderTemplateAdapter,
+				webrtc::Dav1dDecoderTemplateAdapter>>(),
 			  nullptr /*audio_mixer*/,
 			  nullptr /*audio_processing*/);
 		}

--- a/test/include/MediaStreamTrackFactory.hpp
+++ b/test/include/MediaStreamTrackFactory.hpp
@@ -2,6 +2,56 @@
 #define MSC_TEST_MEDIA_STREAM_TRACK_FACTORY_HPP
 
 #include "api/media_stream_interface.h"
+#include "MediaStreamTrackFactory.hpp"
+#include "MediaSoupClientErrors.hpp"
+#include "api/audio_codecs/builtin_audio_decoder_factory.h"
+#include "api/audio_codecs/builtin_audio_encoder_factory.h"
+#include "api/create_peerconnection_factory.h"
+#include "api/video_codecs/builtin_video_decoder_factory.h"
+#include "api/video_codecs/builtin_video_encoder_factory.h"
+#include "pc/test/fake_audio_capture_module.h"
+#include "pc/test/fake_video_track_source.h"
+#include "mediasoupclient.hpp"
+#include <iostream>
+
+
+class Singleton {
+public:
+    static Singleton& getInstance() {
+        static Singleton instance; // 唯一实例
+        return instance;
+    }
+
+    // 防止拷贝和赋值
+    Singleton(const Singleton&) = delete;
+    Singleton& operator=(const Singleton&) = delete;
+
+	void createFactory();
+
+	void ReleaseThreads();
+
+
+	rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> Factory;
+	mediasoupclient::PeerConnection::Options PeerConnectionOptions;
+
+private:
+    Singleton() {
+        std::cout << "Singleton created\n";
+        createFactory();
+    }
+    ~Singleton() {
+        std::cout << "Singleton destroyed\n";
+        ReleaseThreads();
+    }
+
+	/* MediaStreamTrack holds reference to the threads of the PeerConnectionFactory.
+	* Use plain pointers in order to avoid threads being destructed before tracks.
+	*/
+	std::unique_ptr<rtc::Thread> NetworkThread;
+	std::unique_ptr<rtc::Thread> WorkerThread;
+	std::unique_ptr<rtc::Thread> SignalingThread;
+};
+
 
 rtc::scoped_refptr<webrtc::AudioTrackInterface> createAudioTrack(const std::string& label);
 

--- a/test/src/mediasoupclient.test.cpp
+++ b/test/src/mediasoupclient.test.cpp
@@ -7,21 +7,7 @@
 #include <vector>
 #include <iostream>
 
-extern mediasoupclient::PeerConnection::Options PeerConnectionOptions;
-extern void createFactory();
-extern void ReleaseThreads();
 
-struct TestContext {
-    TestContext() {
-        createFactory();
-    }
-
-    ~TestContext() {
-        ReleaseThreads();
-    }
-
-};
-static std::unique_ptr<TestContext> context;
 
 TEST_CASE("mediasoupclient", "[mediasoupclient]")
 {
@@ -51,9 +37,7 @@ TEST_CASE("mediasoupclient", "[mediasoupclient]")
 
 	static json routerRtpCapabilities;
 
-	if (!context) {
-        context = std::make_unique<TestContext>();
-    }
+	Singleton& singleton = Singleton::getInstance();
 
 	SECTION("create a Device succeeds")
 	{
@@ -82,7 +66,7 @@ TEST_CASE("mediasoupclient", "[mediasoupclient]")
 		    TransportRemoteParameters["iceParameters"],
 		    TransportRemoteParameters["iceCandidates"],
 		    TransportRemoteParameters["dtlsParameters"],
-		    &PeerConnectionOptions),
+		    &singleton.PeerConnectionOptions),
 		  MediaSoupClientInvalidStateError);
 	}
 
@@ -154,7 +138,7 @@ TEST_CASE("mediasoupclient", "[mediasoupclient]")
 		  TransportRemoteParameters["iceCandidates"],
 		  TransportRemoteParameters["dtlsParameters"],
 		  TransportRemoteParameters["sctpParameters"],
-		  &PeerConnectionOptions,
+		  &singleton.PeerConnectionOptions,
 		  appData)));
 
 		REQUIRE(sendTransport->GetId() == TransportRemoteParameters["id"].get<std::string>());
@@ -171,7 +155,7 @@ TEST_CASE("mediasoupclient", "[mediasoupclient]")
 		  TransportRemoteParameters["iceParameters"],
 		  TransportRemoteParameters["iceCandidates"],
 		  TransportRemoteParameters["dtlsParameters"],
-		  &PeerConnectionOptions)));
+		  &singleton.PeerConnectionOptions)));
 
 		REQUIRE(recvTransport->GetId() == TransportRemoteParameters["id"].get<std::string>());
 		REQUIRE(!recvTransport->IsClosed());
@@ -346,7 +330,7 @@ TEST_CASE("mediasoupclient", "[mediasoupclient]")
 		  TransportRemoteParameters["iceParameters"],
 		  TransportRemoteParameters["iceCandidates"],
 		  TransportRemoteParameters["dtlsParameters"],
-		  &PeerConnectionOptions,
+		  &singleton.PeerConnectionOptions,
 		  appData)));
 
 		REQUIRE_THROWS_AS(
@@ -832,6 +816,6 @@ TEST_CASE("mediasoupclient", "[mediasoupclient]")
 			sendTransport->UpdateIceServers(iceServers),
 			MediaSoupClientError);
 
-		context = nullptr;
+		// context = nullptr;
 	}
 }


### PR DESCRIPTION
I've upgraded `libmediasoupclient` to WebRTC m120-6099 and also updated the corresponding test demo, `mediasoup-broadcaster-demo`, to the same version. 

This upgrade allows for successful room entry and video stream publishing. 

Testing on a Mac with an M3 Max chip has been successful.