### PR TITLE
Fixed bug.  Can not set stereo opus decoder when stereo is enabled.

### DIFF
--- a/src/sdp/Utils.cpp
+++ b/src/sdp/Utils.cpp
@@ -535,10 +535,9 @@ namespace mediasoupclient
 					{
 						auto jsonSpropStereoIt = codec["parameters"].find("sprop-stereo");
 
-						if (jsonSpropStereoIt != codec["parameters"].end() && jsonSpropStereoIt->is_boolean())
+						if (jsonSpropStereoIt != codec["parameters"].end() && jsonSpropStereoIt->is_number())
 						{
-							auto spropStereo = jsonSpropStereoIt->get<bool>();
-
+							auto spropStereo = jsonSpropStereoIt->get<int>();
 							parameters["stereo"] = spropStereo ? 1 : 0;
 						}
 					}

--- a/src/sdp/Utils.cpp
+++ b/src/sdp/Utils.cpp
@@ -538,6 +538,7 @@ namespace mediasoupclient
 						if (jsonSpropStereoIt != codec["parameters"].end() && jsonSpropStereoIt->is_number())
 						{
 							auto spropStereo = jsonSpropStereoIt->get<int>();
+
 							parameters["stereo"] = spropStereo ? 1 : 0;
 						}
 					}


### PR DESCRIPTION
When offer parameter is enabled stereo, the answer is mistake for check sprop-stereo.