### PR TITLE
Fix selecting a codec in `transport.produce()`

### DIFF
--- a/src/ortc.cpp
+++ b/src/ortc.cpp
@@ -1589,7 +1589,7 @@ namespace mediasoupclient
 			{
 				for (int idx = 0; idx < codecs.size(); ++idx)
 				{
-					if (matchCodecs(codecs[idx], const_cast<json&>(*capCodec)), /*strict*/ true)
+					if (matchCodecs(codecs[idx], const_cast<json&>(*capCodec), /*strict*/ true))
 					{
 						filteredCodecs.push_back(codecs[idx]);
 

--- a/test/src/ortc.test.cpp
+++ b/test/src/ortc.test.cpp
@@ -1,4 +1,5 @@
 #include "ortc.hpp"
+#include "MediaSoupClientErrors.hpp"
 #include "fakeParameters.hpp"
 #include <catch.hpp>
 
@@ -221,5 +222,59 @@ TEST_CASE("ortc::canReceive", "[ortc::canReceive]")
 		})"_json;
 
 		REQUIRE(!ortc::canReceive(rtpParameters, extendedRtpCapabilities));
+	}
+}
+
+TEST_CASE("ortc::reduceCodecs", "[ortc::reduceCodecs]")
+{
+	json caps = generateRouterRtpCapabilities();
+
+	SECTION("if can reduce codecs")
+	{
+		auto capCodec       = R"(
+		{
+			"mimeType"             : "video/H264",
+			"kind"                 : "video",
+			"clockRate"            : 90000,
+			"preferredPayloadType" : 103,
+			"rtcpFeedback"         :
+			[
+				{ "type": "nack" },
+				{ "type": "nack", "parameter": "pli"  },
+				{ "type": "nack", "parameter": "sli"  },
+				{ "type": "nack", "parameter": "rpsi" },
+				{ "type": "nack", "parameter": "app"  },
+				{ "type": "ccm",  "parameter": "fir"  },
+				{ "type": "goog-remb" }
+			],
+			"parameters" :
+			{
+				"level-asymmetry-allowed" : 1,
+				"packetization-mode"      : 1,
+				"profile-level-id"        : "42e01f"
+			}
+		})"_json;
+		json filteredCodecs = ortc::reduceCodecs(caps["codecs"], &capCodec);
+
+		REQUIRE(filteredCodecs[0]["mimeType"] == "video/H264");
+		REQUIRE(filteredCodecs[1]["mimeType"] == "video/rtx");
+	}
+
+	SECTION("it returns the first codec if no capability codec is given")
+	{
+		json capsCodec      = json::array();
+		json filteredCodecs = ortc::reduceCodecs(caps["codecs"], &capsCodec);
+
+		REQUIRE(filteredCodecs[0]["mimeType"] == "audio/opus");
+	}
+
+	SECTION("it throws if codecs doesn't contain a provided codec")
+	{
+		auto capCodec = R"(
+		{
+			"mimeType"             : "video/x-dummy"
+		})"_json;
+
+		REQUIRE_THROWS_AS(ortc::reduceCodecs(caps["codecs"], &capCodec), MediaSoupClientTypeError);
 	}
 }

--- a/test/src/ortc.test.cpp
+++ b/test/src/ortc.test.cpp
@@ -229,7 +229,7 @@ TEST_CASE("ortc::reduceCodecs", "[ortc::reduceCodecs]")
 {
 	json caps = generateRouterRtpCapabilities();
 
-	SECTION("if can reduce codecs")
+	SECTION("it can reduce codecs")
 	{
 		auto capCodec       = R"(
 		{
@@ -260,7 +260,7 @@ TEST_CASE("ortc::reduceCodecs", "[ortc::reduceCodecs]")
 		REQUIRE(filteredCodecs[1]["mimeType"] == "video/rtx");
 	}
 
-	SECTION("it returns the first codec if no capability codec is given")
+	SECTION("it can return the first codec if no capability codec is given")
 	{
 		json capsCodec      = json::array();
 		json filteredCodecs = ortc::reduceCodecs(caps["codecs"], &capsCodec);


### PR DESCRIPTION
Selecting a codec in `transport.produce()` does not work.

This issue was introduced in the referenced commit where the codec check condition was modified. It seems this condition was always returning `true`.

https://github.com/versatica/libmediasoupclient/commit/97c42457b6a73a3eeef45dc37f1c90bb7d28cdff

I have fixed the issue and added a test. Please review it.