### PR TITLE
feat: webrtc m140 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ configure_file (
 )
 
 # C++ standard requirements.
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Project options.

--- a/include/Consumer.hpp
+++ b/include/Consumer.hpp
@@ -18,6 +18,7 @@ namespace mediasoupclient
 		class PrivateListener
 		{
 		public:
+			virtual ~PrivateListener()                                  = default;
 			virtual void OnClose(Consumer* consumer)                    = 0;
 			virtual nlohmann::json OnGetStats(const Consumer* consumer) = 0;
 		};
@@ -26,6 +27,7 @@ namespace mediasoupclient
 		class Listener
 		{
 		public:
+			virtual ~Listener()                               = default;
 			virtual void OnTransportClose(Consumer* consumer) = 0;
 		};
 

--- a/include/DataConsumer.hpp
+++ b/include/DataConsumer.hpp
@@ -15,12 +15,14 @@ namespace mediasoupclient
 		class PrivateListener
 		{
 		public:
+			virtual ~PrivateListener()                       = default;
 			virtual void OnClose(DataConsumer* dataConsumer) = 0;
 		};
 
 		class Listener
 		{
 		public:
+			virtual ~Listener()                                   = default;
 			// DataChannel state changes.
 			virtual void OnConnecting(DataConsumer* dataConsumer) = 0;
 			virtual void OnOpen(DataConsumer* dataConsumer)       = 0;
@@ -39,7 +41,7 @@ namespace mediasoupclient
 		  PrivateListener* privateListener,
 		  const std::string& id,
 		  const std::string& dataProducerId,
-		  rtc::scoped_refptr<webrtc::DataChannelInterface> dataChannel,
+		  webrtc::scoped_refptr<webrtc::DataChannelInterface> dataChannel,
 		  const nlohmann::json& sctpStreamParameters,
 		  const nlohmann::json& appData);
 
@@ -66,7 +68,7 @@ namespace mediasoupclient
 		PrivateListener* privateListener;
 		std::string id;
 		std::string dataProducerId;
-		rtc::scoped_refptr<webrtc::DataChannelInterface> dataChannel;
+		webrtc::scoped_refptr<webrtc::DataChannelInterface> dataChannel;
 		bool closed{ false };
 		nlohmann::json sctpParameters;
 		nlohmann::json appData;

--- a/include/DataProducer.hpp
+++ b/include/DataProducer.hpp
@@ -16,6 +16,7 @@ namespace mediasoupclient
 		class PrivateListener
 		{
 		public:
+			virtual ~PrivateListener()                       = default;
 			virtual void OnClose(DataProducer* dataProducer) = 0;
 		};
 
@@ -23,6 +24,7 @@ namespace mediasoupclient
 		class Listener
 		{
 		public:
+			virtual ~Listener()                                                                    = default;
 			// DataChannel state changes.
 			virtual void OnOpen(DataProducer* dataProducer)                                        = 0;
 			virtual void OnClose(DataProducer* dataProducer)                                       = 0;
@@ -35,7 +37,7 @@ namespace mediasoupclient
 		PrivateListener* privateListener;
 		Listener* listener;
 		std::string id;
-		rtc::scoped_refptr<webrtc::DataChannelInterface> dataChannel;
+		webrtc::scoped_refptr<webrtc::DataChannelInterface> dataChannel;
 		bool closed{ false };
 		nlohmann::json sctpStreamParameters;
 		nlohmann::json appData;
@@ -48,7 +50,7 @@ namespace mediasoupclient
 		  DataProducer::PrivateListener* privateListener,
 		  DataProducer::Listener* listener,
 		  const std::string& id,
-		  rtc::scoped_refptr<webrtc::DataChannelInterface> dataChannel,
+		  webrtc::scoped_refptr<webrtc::DataChannelInterface> dataChannel,
 		  const nlohmann::json& sctpStreamParameters,
 		  const nlohmann::json& appData);
 

--- a/include/Device.hpp
+++ b/include/Device.hpp
@@ -61,7 +61,7 @@ namespace mediasoupclient
 		// Loaded flag.
 		bool loaded{ false };
 		// Extended RTP capabilities.
-		nlohmann::json extendedRtpCapabilities;
+		std::function<nlohmann::json(nlohmann::json&)> getSendExtendedRtpCapabilities;
 		// Local RTP capabilities for receiving media.
 		nlohmann::json recvRtpCapabilities;
 		// Whether we can produce audio/video based on computed extended RTP capabilities.

--- a/include/Handler.hpp
+++ b/include/Handler.hpp
@@ -30,7 +30,7 @@ namespace mediasoupclient
 	public:
 		struct DataChannel
 		{
-			rtc::scoped_refptr<webrtc::DataChannelInterface> dataChannel;
+			webrtc::scoped_refptr<webrtc::DataChannelInterface> dataChannel;
 			nlohmann::json sctpStreamParameters;
 		};
 
@@ -69,7 +69,7 @@ namespace mediasoupclient
 		// Got transport local and remote parameters.
 		bool transportReady{ false };
 		// Map of RTCTransceivers indexed by MID.
-		std::unordered_map<std::string, rtc::scoped_refptr<webrtc::RtpTransceiverInterface>>
+		std::unordered_map<std::string, webrtc::scoped_refptr<webrtc::RtpTransceiverInterface>>
 		  mapMidTransceiver{};
 		// PeerConnection instance.
 		std::unique_ptr<PeerConnection> pc{ nullptr };
@@ -98,8 +98,7 @@ namespace mediasoupclient
 		  const nlohmann::json& dtlsParameters,
 		  const nlohmann::json& sctpParameters,
 		  const PeerConnection::Options* peerConnectionOptions,
-		  const nlohmann::json& sendingRtpParametersByKind,
-		  const nlohmann::json& sendingRemoteRtpParametersByKind = nlohmann::json());
+		  const std::function<nlohmann::json(nlohmann::json&)>& getSendExtendedRtpCapabilities);
 
 	public:
 		SendResult Send(
@@ -115,11 +114,7 @@ namespace mediasoupclient
 		DataChannel SendDataChannel(const std::string& label, webrtc::DataChannelInit dataChannelInit);
 
 	private:
-		// Generic sending RTP parameters for audio and video.
-		nlohmann::json sendingRtpParametersByKind;
-		// Generic sending RTP parameters for audio and video suitable for the SDP
-		// remote answer.
-		nlohmann::json sendingRemoteRtpParametersByKind;
+		const std::function<nlohmann::json(nlohmann::json&)>& getSendExtendedRtpCapabilities;
 	};
 
 	class RecvHandler : public Handler

--- a/include/Handler.hpp
+++ b/include/Handler.hpp
@@ -98,7 +98,7 @@ namespace mediasoupclient
 		  const nlohmann::json& dtlsParameters,
 		  const nlohmann::json& sctpParameters,
 		  const PeerConnection::Options* peerConnectionOptions,
-		  const std::function<nlohmann::json(nlohmann::json&)>& getSendExtendedRtpCapabilities);
+		  const std::function<nlohmann::json(nlohmann::json&)> getSendExtendedRtpCapabilities);
 
 	public:
 		SendResult Send(
@@ -114,7 +114,7 @@ namespace mediasoupclient
 		DataChannel SendDataChannel(const std::string& label, webrtc::DataChannelInit dataChannelInit);
 
 	private:
-		const std::function<nlohmann::json(nlohmann::json&)>& getSendExtendedRtpCapabilities;
+		const std::function<nlohmann::json(nlohmann::json&)> getSendExtendedRtpCapabilities;
 	};
 
 	class RecvHandler : public Handler

--- a/include/PeerConnection.hpp
+++ b/include/PeerConnection.hpp
@@ -18,7 +18,7 @@ namespace mediasoupclient
 			ANSWER
 		};
 
-		static std::map<PeerConnection::SdpType, const std::string> sdpType2String;
+		static std::map<webrtc::SdpType, const webrtc::SdpType> sdpType2webRtcSdpType;
 		static std::map<webrtc::PeerConnectionInterface::IceConnectionState, const std::string>
 		  iceConnectionState2String;
 		static std::map<webrtc::PeerConnectionInterface::IceGatheringState, const std::string>
@@ -31,20 +31,20 @@ namespace mediasoupclient
 			/* Virtual methods inherited from PeerConnectionObserver. */
 		public:
 			void OnSignalingChange(webrtc::PeerConnectionInterface::SignalingState newState) override;
-			void OnAddStream(rtc::scoped_refptr<webrtc::MediaStreamInterface> stream) override;
-			void OnRemoveStream(rtc::scoped_refptr<webrtc::MediaStreamInterface> stream) override;
-			void OnDataChannel(rtc::scoped_refptr<webrtc::DataChannelInterface> dataChannel) override;
+			void OnAddStream(webrtc::scoped_refptr<webrtc::MediaStreamInterface> stream) override;
+			void OnRemoveStream(webrtc::scoped_refptr<webrtc::MediaStreamInterface> stream) override;
+			void OnDataChannel(webrtc::scoped_refptr<webrtc::DataChannelInterface> dataChannel) override;
 			void OnRenegotiationNeeded() override;
 			void OnIceConnectionChange(webrtc::PeerConnectionInterface::IceConnectionState newState) override;
 			void OnIceGatheringChange(webrtc::PeerConnectionInterface::IceGatheringState newState) override;
 			void OnIceCandidate(const webrtc::IceCandidateInterface* candidate) override;
-			void OnIceCandidatesRemoved(const std::vector<cricket::Candidate>& candidates) override;
+			void OnIceCandidatesRemoved(const std::vector<webrtc::Candidate>& candidates) override;
 			void OnIceConnectionReceivingChange(bool receiving) override;
 			void OnAddTrack(
-			  rtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver,
-			  const std::vector<rtc::scoped_refptr<webrtc::MediaStreamInterface>>& streams) override;
-			void OnTrack(rtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver) override;
-			void OnRemoveTrack(rtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver) override;
+			  webrtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver,
+			  const std::vector<webrtc::scoped_refptr<webrtc::MediaStreamInterface>>& streams) override;
+			void OnTrack(webrtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver) override;
+			void OnRemoveTrack(webrtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver) override;
 			void OnInterestingUsage(int usagePattern) override;
 		};
 
@@ -128,7 +128,7 @@ namespace mediasoupclient
 
 			/* Virtual methods inherited from webrtc::RTCStatsCollectorCallback. */
 		public:
-			void OnStatsDelivered(const rtc::scoped_refptr<const webrtc::RTCStatsReport>& report) override;
+			void OnStatsDelivered(const webrtc::scoped_refptr<const webrtc::RTCStatsReport>& report) override;
 
 		private:
 			std::promise<nlohmann::json> promise;
@@ -150,34 +150,34 @@ namespace mediasoupclient
 		bool SetConfiguration(const webrtc::PeerConnectionInterface::RTCConfiguration& config);
 		std::string CreateOffer(const webrtc::PeerConnectionInterface::RTCOfferAnswerOptions& options);
 		std::string CreateAnswer(const webrtc::PeerConnectionInterface::RTCOfferAnswerOptions& options);
-		void SetLocalDescription(PeerConnection::SdpType type, const std::string& sdp);
-		void SetRemoteDescription(PeerConnection::SdpType type, const std::string& sdp);
+		void SetLocalDescription(webrtc::SdpType type, const std::string& sdp);
+		void SetRemoteDescription(webrtc::SdpType type, const std::string& sdp);
 		const std::string GetLocalDescription();
 		const std::string GetRemoteDescription();
-		std::vector<rtc::scoped_refptr<webrtc::RtpTransceiverInterface>> GetTransceivers() const;
-		rtc::scoped_refptr<webrtc::RtpTransceiverInterface> AddTransceiver(cricket::MediaType mediaType);
-		rtc::scoped_refptr<webrtc::RtpTransceiverInterface> AddTransceiver(
-		  rtc::scoped_refptr<webrtc::MediaStreamTrackInterface> track,
+		std::vector<webrtc::scoped_refptr<webrtc::RtpTransceiverInterface>> GetTransceivers() const;
+		webrtc::scoped_refptr<webrtc::RtpTransceiverInterface> AddTransceiver(webrtc::MediaType mediaType);
+		webrtc::scoped_refptr<webrtc::RtpTransceiverInterface> AddTransceiver(
+		  webrtc::scoped_refptr<webrtc::MediaStreamTrackInterface> track,
 		  webrtc::RtpTransceiverInit rtpTransceiverInit);
-		std::vector<rtc::scoped_refptr<webrtc::RtpSenderInterface>> GetSenders();
-		bool RemoveTrack(rtc::scoped_refptr<webrtc::RtpSenderInterface> sender);
+		std::vector<webrtc::scoped_refptr<webrtc::RtpSenderInterface>> GetSenders();
+		bool RemoveTrack(webrtc::scoped_refptr<webrtc::RtpSenderInterface> sender);
 		nlohmann::json GetStats();
-		nlohmann::json GetStats(rtc::scoped_refptr<webrtc::RtpSenderInterface> selector);
-		nlohmann::json GetStats(rtc::scoped_refptr<webrtc::RtpReceiverInterface> selector);
-		rtc::scoped_refptr<webrtc::DataChannelInterface> CreateDataChannel(
+		nlohmann::json GetStats(webrtc::scoped_refptr<webrtc::RtpSenderInterface> selector);
+		nlohmann::json GetStats(webrtc::scoped_refptr<webrtc::RtpReceiverInterface> selector);
+		webrtc::scoped_refptr<webrtc::DataChannelInterface> CreateDataChannel(
 		  const std::string& label, const webrtc::DataChannelInit* config);
 
 	private:
 		// Signaling and worker threads.
-		std::unique_ptr<rtc::Thread> networkThread;
-		std::unique_ptr<rtc::Thread> signalingThread;
-		std::unique_ptr<rtc::Thread> workerThread;
+		std::unique_ptr<webrtc::Thread> networkThread;
+		std::unique_ptr<webrtc::Thread> signalingThread;
+		std::unique_ptr<webrtc::Thread> workerThread;
 
 		// PeerConnection factory.
-		rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> peerConnectionFactory;
+		webrtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> peerConnectionFactory;
 
 		// PeerConnection instance.
-		rtc::scoped_refptr<webrtc::PeerConnectionInterface> pc;
+		webrtc::scoped_refptr<webrtc::PeerConnectionInterface> pc;
 	};
 } // namespace mediasoupclient
 

--- a/include/Producer.hpp
+++ b/include/Producer.hpp
@@ -18,6 +18,7 @@ namespace mediasoupclient
 		class PrivateListener
 		{
 		public:
+			virtual ~PrivateListener()               = default;
 			virtual void OnClose(Producer* producer) = 0;
 			virtual void OnReplaceTrack(
 			  const Producer* producer, webrtc::MediaStreamTrackInterface* newTrack)             = 0;
@@ -29,6 +30,7 @@ namespace mediasoupclient
 		class Listener
 		{
 		public:
+			virtual ~Listener()                               = default;
 			virtual void OnTransportClose(Producer* producer) = 0;
 		};
 

--- a/include/Transport.hpp
+++ b/include/Transport.hpp
@@ -29,9 +29,9 @@ namespace mediasoupclient
 		class Listener
 		{
 		public:
-			virtual ~Listener() = default;
+			virtual ~Listener()                                                                             = default;
 			virtual std::future<void> OnConnect(Transport* transport, const nlohmann::json& dtlsParameters) = 0;
-			virtual void OnConnectionStateChange(Transport* transport, const std::string& connectionState) = 0;
+			virtual void OnConnectionStateChange(Transport* transport, const std::string& connectionState)  = 0;
 		};
 
 		/* Only child classes will create transport intances */
@@ -39,7 +39,6 @@ namespace mediasoupclient
 		Transport(
 		  Listener* listener,
 		  const std::string& id,
-		  const nlohmann::json* extendedRtpCapabilities,
 		  const nlohmann::json& appData);
 
 	public:
@@ -65,8 +64,6 @@ namespace mediasoupclient
 	protected:
 		// Closed flag.
 		bool closed{ false };
-		// Extended RTP capabilities.
-		const nlohmann::json* extendedRtpCapabilities{ nullptr };
 		// SCTP max message size if enabled, null otherwise.
 		size_t maxSctpMessageSize{ 0u };
 		// Whether the Consumer for RTP probation has been created.
@@ -121,7 +118,7 @@ namespace mediasoupclient
 		  const nlohmann::json& dtlsParameters,
 		  const nlohmann::json& sctpParameters,
 		  const PeerConnection::Options* peerConnectionOptions,
-		  const nlohmann::json* extendedRtpCapabilities,
+		  const std::function<nlohmann::json(nlohmann::json&)>& getSendExtendedRtpCapabilities,
 		  const std::map<std::string, bool>* canProduceByKind,
 		  const nlohmann::json& appData);
 
@@ -190,7 +187,7 @@ namespace mediasoupclient
 		  const nlohmann::json& dtlsParameters,
 		  const nlohmann::json& sctpParameters,
 		  const PeerConnection::Options* peerConnectionOptions,
-		  const nlohmann::json* extendedRtpCapabilities,
+		  const nlohmann::json* recvRtpCapabilities,
 		  const nlohmann::json& appData);
 
 		/* Device is the only one constructing Transports */
@@ -230,6 +227,8 @@ namespace mediasoupclient
 		std::unordered_map<std::string, DataConsumer*> dataConsumers;
 		// SendHandler instance.
 		std::unique_ptr<RecvHandler> recvHandler;
+		
+		const nlohmann::json* recvRtpCapabilities;
 	};
 } // namespace mediasoupclient
 #endif

--- a/src/DataConsumer.cpp
+++ b/src/DataConsumer.cpp
@@ -13,7 +13,7 @@ namespace mediasoupclient
 	  DataConsumer::PrivateListener* privateListener,
 	  const std::string& id,
 	  const std::string& dataProducerId,
-	  rtc::scoped_refptr<webrtc::DataChannelInterface> dataChannel,
+	  webrtc::scoped_refptr<webrtc::DataChannelInterface> dataChannel,
 	  const json& sctpStreamParameters,
 	  const json& appData)
 	  : listener(listener), privateListener(privateListener), id(id), dataProducerId(dataProducerId),

--- a/src/DataProducer.cpp
+++ b/src/DataProducer.cpp
@@ -11,7 +11,7 @@ namespace mediasoupclient
 	  DataProducer::PrivateListener* privateListener,
 	  DataProducer::Listener* listener,
 	  const std::string& id,
-	  rtc::scoped_refptr<webrtc::DataChannelInterface> dataChannel,
+	  webrtc::scoped_refptr<webrtc::DataChannelInterface> dataChannel,
 	  const json& sctpStreamParameters,
 	  const json& appData)
 	  : privateListener(privateListener), listener(listener), id(id), dataChannel(dataChannel),

--- a/src/Device.cpp
+++ b/src/Device.cpp
@@ -1,3 +1,4 @@
+#include "Transport.hpp"
 #define MSC_CLASS "Device"
 
 #include "Device.hpp"
@@ -66,32 +67,38 @@ namespace mediasoupclient
 		// This may throw.
 		ortc::validateRtpCapabilities(nativeRtpCapabilities);
 
-		// Get extended RTP capabilities.
-		this->extendedRtpCapabilities =
-		  ortc::getExtendedRtpCapabilities(nativeRtpCapabilities, routerRtpCapabilities);
-
-		MSC_DEBUG("got extended RTP capabilities:\n%s", this->extendedRtpCapabilities.dump(4).c_str());
+		// Get extended RTP capabilities as a function, that SendHandler can invoke to compute the matching capabilities from the current local capabilities.
+		// This is required for WebRTC M140+ where header extension ids may differ from the previosly pre-computed sendExtendedRtpCapabilities, resulting in
+		// failure when setting the generated SDP answer as RemoteDescription, since the header extension ids in the answer do not match those in the offer.
+		// See: https://github.com/versatica/mediasoup-client/pull/336 for the JS counterpart and more rationale.
+		this->getSendExtendedRtpCapabilities = [routerRtpCapabilities](json& currentLocalRtpCapabilities) {
+			auto routerRtpCapabilitiesCopy = routerRtpCapabilities;
+			return ortc::getExtendedRtpCapabilities(currentLocalRtpCapabilities, routerRtpCapabilitiesCopy);
+		};
+		const auto recvExtendedRtpCapabilities =
+			ortc::getExtendedRtpCapabilities(nativeRtpCapabilities, routerRtpCapabilities);
 
 		// Check whether we can produce audio/video.
-		this->canProduceByKind["audio"] = ortc::canSend("audio", this->extendedRtpCapabilities);
-		this->canProduceByKind["video"] = ortc::canSend("video", this->extendedRtpCapabilities);
+		this->canProduceByKind["audio"] = ortc::canSend("audio", recvExtendedRtpCapabilities);
+		this->canProduceByKind["video"] = ortc::canSend("video", recvExtendedRtpCapabilities);
 
 		// Generate our receiving RTP capabilities for receiving media.
-		this->recvRtpCapabilities = ortc::getRecvRtpCapabilities(this->extendedRtpCapabilities);
-
-		MSC_DEBUG("got receiving RTP capabilities:\n%s", this->recvRtpCapabilities.dump(4).c_str());
+		this->recvRtpCapabilities = ortc::getRecvRtpCapabilities(recvExtendedRtpCapabilities);
 
 		// This may throw.
 		ortc::validateRtpCapabilities(this->recvRtpCapabilities);
 
+		MSC_DEBUG("got receiving RTP capabilities:\n%s", this->recvRtpCapabilities.dump(4).c_str());
+	
 		// Generate our SCTP capabilities.
 		this->sctpCapabilities = Handler::GetNativeSctpCapabilities();
-
-		MSC_DEBUG("got receiving SCTP capabilities:\n%s", this->sctpCapabilities.dump(4).c_str());
-
+		
 		// This may throw.
 		ortc::validateSctpCapabilities(this->sctpCapabilities);
 
+		MSC_DEBUG("got receiving SCTP capabilities:\n%s", this->sctpCapabilities.dump(4).c_str());
+
+		
 		MSC_DEBUG("succeeded");
 
 		this->loaded = true;
@@ -147,7 +154,7 @@ namespace mediasoupclient
 		  dtlsParameters,
 		  sctpParameters,
 		  peerConnectionOptions,
-		  &this->extendedRtpCapabilities,
+		  this->getSendExtendedRtpCapabilities,
 		  &this->canProduceByKind,
 		  appData);
 
@@ -203,7 +210,7 @@ namespace mediasoupclient
 		  dtlsParameters,
 		  sctpParameters,
 		  peerConnectionOptions,
-		  &this->extendedRtpCapabilities,
+		  &this->recvRtpCapabilities,
 		  appData);
 
 		return transport;

--- a/src/Handler.cpp
+++ b/src/Handler.cpp
@@ -34,8 +34,8 @@ namespace mediasoupclient
 		std::unique_ptr<PeerConnection> pc(
 		  new PeerConnection(privateListener.get(), peerConnectionOptions));
 
-		(void)pc->AddTransceiver(cricket::MediaType::MEDIA_TYPE_AUDIO);
-		(void)pc->AddTransceiver(cricket::MediaType::MEDIA_TYPE_VIDEO);
+		(void)pc->AddTransceiver(webrtc::MediaType::AUDIO);
+		(void)pc->AddTransceiver(webrtc::MediaType::VIDEO);
 
 		webrtc::PeerConnectionInterface::RTCOfferAnswerOptions options;
 
@@ -158,16 +158,12 @@ namespace mediasoupclient
 	  const json& dtlsParameters,
 	  const json& sctpParameters,
 	  const PeerConnection::Options* peerConnectionOptions,
-	  const json& sendingRtpParametersByKind,
-	  const json& sendingRemoteRtpParametersByKind)
+	  const std::function<nlohmann::json(nlohmann::json&)>& getSendExtendedRtpCapabilities)
 	  : Handler(
 	      privateListener, iceParameters, iceCandidates, dtlsParameters, sctpParameters, peerConnectionOptions)
+	  , getSendExtendedRtpCapabilities(getSendExtendedRtpCapabilities)
 	{
 		MSC_TRACE();
-
-		this->sendingRtpParametersByKind = sendingRtpParametersByKind;
-
-		this->sendingRemoteRtpParametersByKind = sendingRemoteRtpParametersByKind;
 	};
 
 	SendHandler::SendResult SendHandler::Send(
@@ -193,17 +189,6 @@ namespace mediasoupclient
 			}
 		}
 
-		json sendingRtpParameters = this->sendingRtpParametersByKind[track->kind()];
-
-		// This may throw.
-		sendingRtpParameters["codecs"] = ortc::reduceCodecs(sendingRtpParameters["codecs"], codec);
-
-		json sendingRemoteRtpParameters = this->sendingRemoteRtpParametersByKind[track->kind()];
-
-		// This may throw.
-		sendingRemoteRtpParameters["codecs"] =
-		  ortc::reduceCodecs(sendingRemoteRtpParameters["codecs"], codec);
-
 		const Sdp::RemoteSdp::MediaSectionIdx mediaSectionIdx = this->remoteSdp->GetNextMediaSectionIdx();
 
 		webrtc::RtpTransceiverInit transceiverInit;
@@ -212,7 +197,7 @@ namespace mediasoupclient
 		if (encodings && !encodings->empty())
 			transceiverInit.send_encodings = *encodings;
 
-		rtc::scoped_refptr<webrtc::MediaStreamTrackInterface> scopedTrack{ track };
+		webrtc::scoped_refptr<webrtc::MediaStreamTrackInterface> scopedTrack{ track };
 		auto transceiver = this->pc->AddTransceiver(scopedTrack, transceiverInit);
 
 		if (!transceiver)
@@ -220,17 +205,45 @@ namespace mediasoupclient
 
 		std::string offer;
 		std::string localId;
-
-		// Special case for VP9 with SVC.
-		bool hackVp9Svc = false;
+		json localSdpObject;
 
 		try
 		{
 			webrtc::PeerConnectionInterface::RTCOfferAnswerOptions options;
 
 			offer               = this->pc->CreateOffer(options);
-			auto localSdpObject = sdptransform::parse(offer);
+			localSdpObject      = sdptransform::parse(offer);
+		}
+		catch (std::exception& error)
+		{
+			// Panic here. Try to undo things.
+			transceiver->SetDirectionWithError(webrtc::RtpTransceiverDirection::kInactive);
+			transceiver->sender()->SetTrack(nullptr);
 
+			throw error;
+		}
+		auto nativeRtpCapabilities = Sdp::Utils::extractRtpCapabilities(localSdpObject);
+		auto sendExtendedRtpCapabilities =
+		  this->getSendExtendedRtpCapabilities(nativeRtpCapabilities);
+
+		// Create sending parameters based on the offer.
+		json sendingRtpParameters = ortc::getSendingRtpParameters(track->kind(), sendExtendedRtpCapabilities);
+
+		// This may throw.
+		sendingRtpParameters["codecs"] = ortc::reduceCodecs(sendingRtpParameters["codecs"], codec);
+
+		json sendingRemoteRtpParameters = ortc::getSendingRemoteRtpParameters(track->kind(), sendExtendedRtpCapabilities);
+
+		// This may throw.
+		sendingRemoteRtpParameters["codecs"] =
+		  ortc::reduceCodecs(sendingRemoteRtpParameters["codecs"], codec);
+
+
+		// Special case for VP9 with SVC.
+		bool hackVp9Svc = false;
+
+		try
+		{
 			// Transport is not ready.
 			if (!this->transportReady)
 				this->SetupTransport(
@@ -255,7 +268,6 @@ namespace mediasoupclient
 				MSC_DEBUG("send() | enabling legacy simulcast for VP9 SVC");
 
 				hackVp9Svc             = true;
-				localSdpObject         = sdptransform::parse(offer);
 				json& offerMediaObject = localSdpObject["media"][mediaSectionIdx.idx];
 
 				Sdp::Utils::addLegacySimulcast(offerMediaObject, spatialLayers);
@@ -265,7 +277,7 @@ namespace mediasoupclient
 
 			MSC_DEBUG("calling pc->SetLocalDescription():\n%s", offer.c_str());
 
-			this->pc->SetLocalDescription(PeerConnection::SdpType::OFFER, offer);
+			this->pc->SetLocalDescription(webrtc::SdpType::kOffer, offer);
 
 			// We can now get the transceiver.mid.
 			localId = transceiver->mid().value();
@@ -279,11 +291,8 @@ namespace mediasoupclient
 			transceiver->SetDirectionWithError(webrtc::RtpTransceiverDirection::kInactive);
 			transceiver->sender()->SetTrack(nullptr);
 
-			throw;
+			throw error;
 		}
-
-		auto localSdp       = this->pc->GetLocalDescription();
-		auto localSdpObject = sdptransform::parse(localSdp);
 
 		json& offerMediaObject = localSdpObject["media"][mediaSectionIdx.idx];
 
@@ -352,7 +361,7 @@ namespace mediasoupclient
 
 		MSC_DEBUG("calling pc->SetRemoteDescription():\n%s", answer.c_str());
 
-		this->pc->SetRemoteDescription(PeerConnection::SdpType::ANSWER, answer);
+		this->pc->SetRemoteDescription(webrtc::SdpType::kAnswer, answer);
 
 		// Store in the map.
 		this->mapMidTransceiver[localId] = transceiver;
@@ -398,7 +407,7 @@ namespace mediasoupclient
 		// This will fill sctpStreamParameters's missing fields with default values.
 		ortc::validateSctpStreamParameters(sctpStreamParameters);
 
-		rtc::scoped_refptr<webrtc::DataChannelInterface> webrtcDataChannel =
+		webrtc::scoped_refptr<webrtc::DataChannelInterface> webrtcDataChannel =
 		  this->pc->CreateDataChannel(label, &dataChannelInit);
 
 		// Increase next id.
@@ -432,14 +441,14 @@ namespace mediasoupclient
 
 			MSC_DEBUG("calling pc.setLocalDescription() [offer:%s]", offer.c_str());
 
-			this->pc->SetLocalDescription(PeerConnection::SdpType::OFFER, offer);
+			this->pc->SetLocalDescription(webrtc::SdpType::kOffer, offer);
 			this->remoteSdp->SendSctpAssociation(*offerMediaObject);
 
 			auto sdpAnswer = this->remoteSdp->GetSdp();
 
 			MSC_DEBUG("calling pc.setRemoteDescription() [answer:%s]", sdpAnswer.c_str());
 
-			this->pc->SetRemoteDescription(PeerConnection::SdpType::ANSWER, sdpAnswer);
+			this->pc->SetRemoteDescription(webrtc::SdpType::kAnswer, sdpAnswer);
 			this->hasDataChannelMediaSection = true;
 		}
 
@@ -476,7 +485,7 @@ namespace mediasoupclient
 		MSC_DEBUG("calling pc->SetLocalDescription():\n%s", offer.c_str());
 
 		// May throw.
-		this->pc->SetLocalDescription(PeerConnection::SdpType::OFFER, offer);
+		this->pc->SetLocalDescription(webrtc::SdpType::kOffer, offer);
 
 		auto localSdpObj = sdptransform::parse(this->pc->GetLocalDescription());
 		auto answer      = this->remoteSdp->GetSdp();
@@ -484,7 +493,7 @@ namespace mediasoupclient
 		MSC_DEBUG("calling pc->SetRemoteDescription():\n%s", answer.c_str());
 
 		// May throw.
-		this->pc->SetRemoteDescription(PeerConnection::SdpType::ANSWER, answer);
+		this->pc->SetRemoteDescription(webrtc::SdpType::kAnswer, answer);
 	}
 
 	void SendHandler::ReplaceTrack(const std::string& localId, webrtc::MediaStreamTrackInterface* track)
@@ -609,7 +618,7 @@ namespace mediasoupclient
 		MSC_DEBUG("calling pc->SetLocalDescription():\n%s", offer.c_str());
 
 		// May throw.
-		this->pc->SetLocalDescription(PeerConnection::SdpType::OFFER, offer);
+		this->pc->SetLocalDescription(webrtc::SdpType::kOffer, offer);
 
 		auto localSdpObj = sdptransform::parse(this->pc->GetLocalDescription());
 		auto answer      = this->remoteSdp->GetSdp();
@@ -617,7 +626,7 @@ namespace mediasoupclient
 		MSC_DEBUG("calling pc->SetRemoteDescription():\n%s", answer.c_str());
 
 		// May throw.
-		this->pc->SetRemoteDescription(PeerConnection::SdpType::ANSWER, answer);
+		this->pc->SetRemoteDescription(webrtc::SdpType::kAnswer, answer);
 	}
 
 	/* RecvHandler methods */
@@ -660,7 +669,7 @@ namespace mediasoupclient
 		MSC_DEBUG("calling pc->setRemoteDescription():\n%s", offer.c_str());
 
 		// May throw.
-		this->pc->SetRemoteDescription(PeerConnection::SdpType::OFFER, offer);
+		this->pc->SetRemoteDescription(webrtc::SdpType::kOffer, offer);
 
 		webrtc::PeerConnectionInterface::RTCOfferAnswerOptions options;
 
@@ -687,13 +696,13 @@ namespace mediasoupclient
 		MSC_DEBUG("calling pc->SetLocalDescription():\n%s", answer.c_str());
 
 		// May throw.
-		this->pc->SetLocalDescription(PeerConnection::SdpType::ANSWER, answer);
+		this->pc->SetLocalDescription(webrtc::SdpType::kAnswer, answer);
 
 		auto transceivers  = this->pc->GetTransceivers();
 		auto transceiverIt = std::find_if(
 		  transceivers.begin(),
 		  transceivers.end(),
-		  [&localId](rtc::scoped_refptr<webrtc::RtpTransceiverInterface> t)
+		  [&localId](webrtc::scoped_refptr<webrtc::RtpTransceiverInterface> t)
 		  { return t->mid() == localId; });
 
 		if (transceiverIt == transceivers.end())
@@ -731,7 +740,7 @@ namespace mediasoupclient
 		// This will fill sctpStreamParameters's missing fields with default values.
 		ortc::validateSctpStreamParameters(sctpStreamParameters);
 
-		rtc::scoped_refptr<webrtc::DataChannelInterface> webrtcDataChannel =
+		webrtc::scoped_refptr<webrtc::DataChannelInterface> webrtcDataChannel =
 		  this->pc->CreateDataChannel(label, &dataChannelInit);
 
 		// If this is the first DataChannel we need to create the SDP answer with
@@ -744,7 +753,7 @@ namespace mediasoupclient
 			MSC_DEBUG("calling pc->setRemoteDescription() [offer:%s]", sdpOffer.c_str());
 
 			// May throw.
-			this->pc->SetRemoteDescription(PeerConnection::SdpType::OFFER, sdpOffer);
+			this->pc->SetRemoteDescription(webrtc::SdpType::kOffer, sdpOffer);
 
 			webrtc::PeerConnectionInterface::RTCOfferAnswerOptions options;
 			auto sdpAnswer = this->pc->CreateAnswer(options);
@@ -759,7 +768,7 @@ namespace mediasoupclient
 			MSC_DEBUG("calling pc->setLocalDescription() [answer: %s]", sdpAnswer.c_str());
 
 			// May throw.
-			this->pc->SetLocalDescription(PeerConnection::SdpType::ANSWER, sdpAnswer);
+			this->pc->SetLocalDescription(webrtc::SdpType::kAnswer, sdpAnswer);
 
 			this->hasDataChannelMediaSection = true;
 		}
@@ -794,7 +803,7 @@ namespace mediasoupclient
 		MSC_DEBUG("calling pc->setRemoteDescription():\n%s", offer.c_str());
 
 		// May throw.
-		this->pc->SetRemoteDescription(PeerConnection::SdpType::OFFER, offer);
+		this->pc->SetRemoteDescription(webrtc::SdpType::kOffer, offer);
 
 		webrtc::PeerConnectionInterface::RTCOfferAnswerOptions options;
 
@@ -804,7 +813,7 @@ namespace mediasoupclient
 		MSC_DEBUG("calling pc->SetLocalDescription():\n%s", answer.c_str());
 
 		// May throw.
-		this->pc->SetLocalDescription(PeerConnection::SdpType::ANSWER, answer);
+		this->pc->SetLocalDescription(webrtc::SdpType::kAnswer, answer);
 	}
 
 	json RecvHandler::GetReceiverStats(const std::string& localId)
@@ -841,7 +850,7 @@ namespace mediasoupclient
 		MSC_DEBUG("calling pc->setRemoteDescription():\n%s", offer.c_str());
 
 		// May throw.
-		this->pc->SetRemoteDescription(PeerConnection::SdpType::OFFER, offer);
+		this->pc->SetRemoteDescription(webrtc::SdpType::kOffer, offer);
 
 		webrtc::PeerConnectionInterface::RTCOfferAnswerOptions options;
 
@@ -851,7 +860,7 @@ namespace mediasoupclient
 		MSC_DEBUG("calling pc->SetLocalDescription():\n%s", answer.c_str());
 
 		// May throw.
-		this->pc->SetLocalDescription(PeerConnection::SdpType::ANSWER, answer);
+		this->pc->SetLocalDescription(webrtc::SdpType::kAnswer, answer);
 	}
 } // namespace mediasoupclient
 

--- a/src/Handler.cpp
+++ b/src/Handler.cpp
@@ -158,7 +158,7 @@ namespace mediasoupclient
 	  const json& dtlsParameters,
 	  const json& sctpParameters,
 	  const PeerConnection::Options* peerConnectionOptions,
-	  const std::function<nlohmann::json(nlohmann::json&)>& getSendExtendedRtpCapabilities)
+	  const std::function<nlohmann::json(nlohmann::json&)> getSendExtendedRtpCapabilities)
 	  : Handler(
 	      privateListener, iceParameters, iceCandidates, dtlsParameters, sctpParameters, peerConnectionOptions)
 	  , getSendExtendedRtpCapabilities(getSendExtendedRtpCapabilities)

--- a/src/PeerConnection.cpp
+++ b/src/PeerConnection.cpp
@@ -1,23 +1,23 @@
+#include "api/jsep.h"
+#include "api/peer_connection_interface.h"
 #define MSC_CLASS "PeerConnection"
 
 #include "PeerConnection.hpp"
 #include "Logger.hpp"
 #include "MediaSoupClientErrors.hpp"
-#include "Utils.hpp"
 #include <api/audio_codecs/builtin_audio_decoder_factory.h>
 #include <api/audio_codecs/builtin_audio_encoder_factory.h>
 #include <api/create_peerconnection_factory.h>
 #include <api/video_codecs/builtin_video_decoder_factory.h>
 #include <api/video_codecs/builtin_video_encoder_factory.h>
+#include <api/field_trials.h>
 #include <rtc_base/ssl_adapter.h>
 
-#include "api/video_codecs/video_decoder_factory.h"
 #include "api/video_codecs/video_decoder_factory_template.h"
 #include "api/video_codecs/video_decoder_factory_template_dav1d_adapter.h"
 #include "api/video_codecs/video_decoder_factory_template_libvpx_vp8_adapter.h"
 #include "api/video_codecs/video_decoder_factory_template_libvpx_vp9_adapter.h"
 #include "api/video_codecs/video_decoder_factory_template_open_h264_adapter.h"
-#include "api/video_codecs/video_encoder_factory.h"
 #include "api/video_codecs/video_encoder_factory_template.h"
 #include "api/video_codecs/video_encoder_factory_template_libaom_av1_adapter.h"
 #include "api/video_codecs/video_encoder_factory_template_libvpx_vp8_adapter.h"
@@ -31,13 +31,6 @@ namespace mediasoupclient
 	/* Static. */
 
 	// clang-format off
-	std::map<PeerConnection::SdpType, const std::string> PeerConnection::sdpType2String =
-	{
-		{ PeerConnection::SdpType::OFFER,    "offer"    },
-		{ PeerConnection::SdpType::PRANSWER, "pranswer" },
-		{ PeerConnection::SdpType::ANSWER,   "answer"   }
-	};
-
 	std::map<webrtc::PeerConnectionInterface::IceConnectionState, const std::string>
 		PeerConnection::iceConnectionState2String =
 	{
@@ -86,13 +79,13 @@ namespace mediasoupclient
 		if ((options != nullptr) && (options->factory != nullptr))
 		{
 			this->peerConnectionFactory =
-			  rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface>(options->factory);
+			  webrtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface>(options->factory);
 		}
 		else
 		{
-			this->networkThread   = rtc::Thread::CreateWithSocketServer();
-			this->signalingThread = rtc::Thread::Create();
-			this->workerThread    = rtc::Thread::Create();
+			this->networkThread   = webrtc::Thread::CreateWithSocketServer();
+			this->signalingThread = webrtc::Thread::Create();
+			this->workerThread    = webrtc::Thread::Create();
 
 			this->networkThread->SetName("network_thread", nullptr);
 			this->signalingThread->SetName("signaling_thread", nullptr);
@@ -102,6 +95,8 @@ namespace mediasoupclient
 			{
 				MSC_THROW_INVALID_STATE_ERROR("thread start errored");
 			}
+			auto trials = "WebRTC-SupportVP9SVC/EnabledByFlag_3SL3TL/";
+			auto field_trials = webrtc::FieldTrials::Create(trials);
 
 			this->peerConnectionFactory = webrtc::CreatePeerConnectionFactory(
 			  this->networkThread.get(),
@@ -121,15 +116,22 @@ namespace mediasoupclient
 			    webrtc::OpenH264DecoderTemplateAdapter,
 			    webrtc::Dav1dDecoderTemplateAdapter>>(),
 			  nullptr /*audio_mixer*/,
-			  nullptr /*audio_processing*/);
+			  nullptr /*audio_processing*/,
+			  nullptr /*audio_frame_processor*/,
+			  std::move(field_trials));
 		}
 
 		// Set SDP semantics to Unified Plan.
 		config.sdp_semantics = webrtc::SdpSemantics::kUnifiedPlan;
 
 		// Create the webrtc::Peerconnection.
-		this->pc =
-		  this->peerConnectionFactory->CreatePeerConnection(config, nullptr, nullptr, privateListener);
+		auto pc_or_error =
+		  this->peerConnectionFactory->CreatePeerConnectionOrError(config,
+							     webrtc::PeerConnectionDependencies{privateListener});
+		if (!pc_or_error.ok()) {
+			MSC_THROW_INVALID_STATE_ERROR("failed to create peer connection: %s", pc_or_error.error().message());
+		}
+		this->pc = pc_or_error.value();
 	}
 
 	void PeerConnection::Close()
@@ -171,7 +173,7 @@ namespace mediasoupclient
 		MSC_TRACE();
 
 		CreateSessionDescriptionObserver* sessionDescriptionObserver =
-		  new rtc::RefCountedObject<CreateSessionDescriptionObserver>();
+		  new webrtc::RefCountedObject<CreateSessionDescriptionObserver>();
 
 		auto future = sessionDescriptionObserver->GetFuture();
 
@@ -186,7 +188,7 @@ namespace mediasoupclient
 		MSC_TRACE();
 
 		CreateSessionDescriptionObserver* sessionDescriptionObserver =
-		  new rtc::RefCountedObject<CreateSessionDescriptionObserver>();
+		  new webrtc::RefCountedObject<CreateSessionDescriptionObserver>();
 
 		auto future = sessionDescriptionObserver->GetFuture();
 
@@ -195,19 +197,18 @@ namespace mediasoupclient
 		return future.get();
 	}
 
-	void PeerConnection::SetLocalDescription(PeerConnection::SdpType type, const std::string& sdp)
+	void PeerConnection::SetLocalDescription(webrtc::SdpType type, const std::string& sdp)
 	{
 		MSC_TRACE();
 
 		webrtc::SdpParseError error;
 		std::unique_ptr<webrtc::SessionDescriptionInterface> sessionDescription;
-		rtc::scoped_refptr<SetLocalDescriptionObserver> observer(
-		  new rtc::RefCountedObject<SetLocalDescriptionObserver>());
+		webrtc::scoped_refptr<SetLocalDescriptionObserver> observer(
+		  new webrtc::RefCountedObject<SetLocalDescriptionObserver>());
 
-		const auto& typeStr = sdpType2String[type];
 		auto future         = observer->GetFuture();
 
-		sessionDescription.reset(webrtc::CreateSessionDescription(typeStr, sdp, &error));
+		sessionDescription = webrtc::CreateSessionDescription(type, sdp, &error);
 		if (sessionDescription == nullptr)
 		{
 			MSC_WARN(
@@ -225,19 +226,18 @@ namespace mediasoupclient
 		return future.get();
 	}
 
-	void PeerConnection::SetRemoteDescription(PeerConnection::SdpType type, const std::string& sdp)
+	void PeerConnection::SetRemoteDescription(webrtc::SdpType type, const std::string& sdp)
 	{
 		MSC_TRACE();
 
 		webrtc::SdpParseError error;
 		std::unique_ptr<webrtc::SessionDescriptionInterface> sessionDescription;
-		rtc::scoped_refptr<SetRemoteDescriptionObserver> observer(
-		  new rtc::RefCountedObject<SetRemoteDescriptionObserver>());
+		webrtc::scoped_refptr<SetRemoteDescriptionObserver> observer(
+		  new webrtc::RefCountedObject<SetRemoteDescriptionObserver>());
 
-		const auto& typeStr = sdpType2String[type];
 		auto future         = observer->GetFuture();
 
-		sessionDescription.reset(webrtc::CreateSessionDescription(typeStr, sdp, &error));
+		sessionDescription = webrtc::CreateSessionDescription(type, sdp, &error);
 		if (sessionDescription == nullptr)
 		{
 			MSC_WARN(
@@ -279,15 +279,15 @@ namespace mediasoupclient
 		return sdp;
 	}
 
-	std::vector<rtc::scoped_refptr<webrtc::RtpTransceiverInterface>> PeerConnection::GetTransceivers() const
+	std::vector<webrtc::scoped_refptr<webrtc::RtpTransceiverInterface>> PeerConnection::GetTransceivers() const
 	{
 		MSC_TRACE();
 
 		return this->pc->GetTransceivers();
 	}
 
-	rtc::scoped_refptr<webrtc::RtpTransceiverInterface> PeerConnection::AddTransceiver(
-	  cricket::MediaType mediaType)
+	webrtc::scoped_refptr<webrtc::RtpTransceiverInterface> PeerConnection::AddTransceiver(
+	  webrtc::MediaType mediaType)
 	{
 		MSC_TRACE();
 
@@ -295,7 +295,7 @@ namespace mediasoupclient
 
 		if (!result.ok())
 		{
-			rtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver = nullptr;
+			webrtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver = nullptr;
 
 			return transceiver;
 		}
@@ -303,8 +303,8 @@ namespace mediasoupclient
 		return result.value();
 	}
 
-	rtc::scoped_refptr<webrtc::RtpTransceiverInterface> PeerConnection::AddTransceiver(
-	  rtc::scoped_refptr<webrtc::MediaStreamTrackInterface> track,
+	webrtc::scoped_refptr<webrtc::RtpTransceiverInterface> PeerConnection::AddTransceiver(
+	  webrtc::scoped_refptr<webrtc::MediaStreamTrackInterface> track,
 	  webrtc::RtpTransceiverInit rtpTransceiverInit)
 	{
 		MSC_TRACE();
@@ -323,7 +323,7 @@ namespace mediasoupclient
 
 		if (!result.ok())
 		{
-			rtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver = nullptr;
+			webrtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver = nullptr;
 
 			return transceiver;
 		}
@@ -331,14 +331,14 @@ namespace mediasoupclient
 		return result.value();
 	}
 
-	std::vector<rtc::scoped_refptr<webrtc::RtpSenderInterface>> PeerConnection::GetSenders()
+	std::vector<webrtc::scoped_refptr<webrtc::RtpSenderInterface>> PeerConnection::GetSenders()
 	{
 		MSC_TRACE();
 
 		return this->pc->GetSenders();
 	}
 
-	bool PeerConnection::RemoveTrack(rtc::scoped_refptr<webrtc::RtpSenderInterface> sender)
+	bool PeerConnection::RemoveTrack(webrtc::scoped_refptr<webrtc::RtpSenderInterface> sender)
 	{
 		MSC_TRACE();
 
@@ -351,8 +351,8 @@ namespace mediasoupclient
 	{
 		MSC_TRACE();
 
-		rtc::scoped_refptr<RTCStatsCollectorCallback> callback(
-		  new rtc::RefCountedObject<RTCStatsCollectorCallback>());
+		webrtc::scoped_refptr<RTCStatsCollectorCallback> callback(
+		  new webrtc::RefCountedObject<RTCStatsCollectorCallback>());
 
 		auto future = callback->GetFuture();
 
@@ -361,12 +361,12 @@ namespace mediasoupclient
 		return future.get();
 	}
 
-	json PeerConnection::GetStats(rtc::scoped_refptr<webrtc::RtpSenderInterface> selector)
+	json PeerConnection::GetStats(webrtc::scoped_refptr<webrtc::RtpSenderInterface> selector)
 	{
 		MSC_TRACE();
 
-		rtc::scoped_refptr<RTCStatsCollectorCallback> callback(
-		  new rtc::RefCountedObject<RTCStatsCollectorCallback>());
+		webrtc::scoped_refptr<RTCStatsCollectorCallback> callback(
+		  new webrtc::RefCountedObject<RTCStatsCollectorCallback>());
 
 		auto future = callback->GetFuture();
 
@@ -375,12 +375,12 @@ namespace mediasoupclient
 		return future.get();
 	}
 
-	json PeerConnection::GetStats(rtc::scoped_refptr<webrtc::RtpReceiverInterface> selector)
+	json PeerConnection::GetStats(webrtc::scoped_refptr<webrtc::RtpReceiverInterface> selector)
 	{
 		MSC_TRACE();
 
-		rtc::scoped_refptr<RTCStatsCollectorCallback> callback(
-		  new rtc::RefCountedObject<RTCStatsCollectorCallback>());
+		webrtc::scoped_refptr<RTCStatsCollectorCallback> callback(
+		  new webrtc::RefCountedObject<RTCStatsCollectorCallback>());
 
 		auto future = callback->GetFuture();
 
@@ -389,7 +389,7 @@ namespace mediasoupclient
 		return future.get();
 	}
 
-	rtc::scoped_refptr<webrtc::DataChannelInterface> PeerConnection::CreateDataChannel(
+	webrtc::scoped_refptr<webrtc::DataChannelInterface> PeerConnection::CreateDataChannel(
 	  const std::string& label, const webrtc::DataChannelInit* config)
 	{
 		MSC_TRACE();
@@ -573,7 +573,7 @@ namespace mediasoupclient
 	}
 
 	void PeerConnection::RTCStatsCollectorCallback::OnStatsDelivered(
-	  const rtc::scoped_refptr<const webrtc::RTCStatsReport>& report)
+	  const webrtc::scoped_refptr<const webrtc::RTCStatsReport>& report)
 	{
 		MSC_TRACE();
 
@@ -603,7 +603,7 @@ namespace mediasoupclient
 	 * Triggered when media is received on a new stream from remote peer.
 	 */
 	void PeerConnection::PrivateListener::OnAddStream(
-	  rtc::scoped_refptr<webrtc::MediaStreamInterface> /*stream*/)
+	  webrtc::scoped_refptr<webrtc::MediaStreamInterface> /*stream*/)
 	{
 		MSC_TRACE();
 	}
@@ -612,7 +612,7 @@ namespace mediasoupclient
 	 * Triggered when a remote peer closes a stream.
 	 */
 	void PeerConnection::PrivateListener::OnRemoveStream(
-	  rtc::scoped_refptr<webrtc::MediaStreamInterface> /*stream*/)
+	  webrtc::scoped_refptr<webrtc::MediaStreamInterface> /*stream*/)
 	{
 		MSC_TRACE();
 	}
@@ -621,7 +621,7 @@ namespace mediasoupclient
 	 * Triggered when a remote peer opens a data channel.
 	 */
 	void PeerConnection::PrivateListener::OnDataChannel(
-	  rtc::scoped_refptr<webrtc::DataChannelInterface> /*dataChannel*/)
+	  webrtc::scoped_refptr<webrtc::DataChannelInterface> /*dataChannel*/)
 	{
 		MSC_TRACE();
 	}
@@ -679,7 +679,7 @@ namespace mediasoupclient
 	 * Triggered when the ICE candidates have been removed.
 	 */
 	void PeerConnection::PrivateListener::OnIceCandidatesRemoved(
-	  const std::vector<cricket::Candidate>& /*candidates*/)
+	  const std::vector<webrtc::Candidate>& /*candidates*/)
 	{
 		MSC_TRACE();
 	}
@@ -700,8 +700,8 @@ namespace mediasoupclient
 	 * compatibility (and is called in the exact same situations as OnTrack).
 	 */
 	void PeerConnection::PrivateListener::OnAddTrack(
-	  rtc::scoped_refptr<webrtc::RtpReceiverInterface> /*receiver*/,
-	  const std::vector<rtc::scoped_refptr<webrtc::MediaStreamInterface>>& /*streams*/)
+	  webrtc::scoped_refptr<webrtc::RtpReceiverInterface> /*receiver*/,
+	  const std::vector<webrtc::scoped_refptr<webrtc::MediaStreamInterface>>& /*streams*/)
 	{
 		MSC_TRACE();
 	}
@@ -720,7 +720,7 @@ namespace mediasoupclient
 	 *   https://w3c.github.io/webrtc-pc/#set-description
 	 */
 	void PeerConnection::PrivateListener::OnTrack(
-	  rtc::scoped_refptr<webrtc::RtpTransceiverInterface> /*transceiver*/)
+	  webrtc::scoped_refptr<webrtc::RtpTransceiverInterface> /*transceiver*/)
 	{
 		MSC_TRACE();
 	}
@@ -736,7 +736,7 @@ namespace mediasoupclient
 	 *   https://w3c.github.io/webrtc-pc/#process-remote-track-removal
 	 */
 	void PeerConnection::PrivateListener::OnRemoveTrack(
-	  rtc::scoped_refptr<webrtc::RtpReceiverInterface> /*receiver*/)
+	  webrtc::scoped_refptr<webrtc::RtpReceiverInterface> /*receiver*/)
 	{
 		MSC_TRACE();
 	}

--- a/src/Transport.cpp
+++ b/src/Transport.cpp
@@ -12,8 +12,8 @@ namespace mediasoupclient
 	/* Transport */
 
 	Transport::Transport(
-	  Listener* listener, const std::string& id, const json* extendedRtpCapabilities, const json& appData)
-	  : extendedRtpCapabilities(extendedRtpCapabilities), listener(listener), id(id), appData(appData)
+	  Listener* listener, const std::string& id, const json& appData)
+	  : listener(listener), id(id), appData(appData)
 	{
 		MSC_TRACE();
 	}
@@ -128,11 +128,11 @@ namespace mediasoupclient
 	  const json& dtlsParameters,
 	  const json& sctpParameters,
 	  const PeerConnection::Options* peerConnectionOptions,
-	  const json* extendedRtpCapabilities,
+	  const std::function<nlohmann::json(nlohmann::json&)>& getSendExtendedRtpCapabilities,
 	  const std::map<std::string, bool>* canProduceByKind,
 	  const json& appData)
 
-	  : Transport(listener, id, extendedRtpCapabilities, appData), listener(listener),
+	  : Transport(listener, id, appData), listener(listener),
 	    canProduceByKind(canProduceByKind)
 	{
 		MSC_TRACE();
@@ -146,16 +146,6 @@ namespace mediasoupclient
 				this->maxSctpMessageSize = maxMessageSizeIt->get<size_t>();
 		}
 
-		json sendingRtpParametersByKind = {
-			{ "audio", ortc::getSendingRtpParameters("audio", *extendedRtpCapabilities) },
-			{ "video", ortc::getSendingRtpParameters("video", *extendedRtpCapabilities) }
-		};
-
-		json sendingRemoteRtpParametersByKind = {
-			{ "audio", ortc::getSendingRemoteRtpParameters("audio", *extendedRtpCapabilities) },
-			{ "video", ortc::getSendingRemoteRtpParameters("video", *extendedRtpCapabilities) }
-		};
-
 		this->sendHandler.reset(new SendHandler(
 		  dynamic_cast<SendHandler::PrivateListener*>(this),
 		  iceParameters,
@@ -163,8 +153,7 @@ namespace mediasoupclient
 		  dtlsParameters,
 		  sctpParameters,
 		  peerConnectionOptions,
-		  sendingRtpParametersByKind,
-		  sendingRemoteRtpParametersByKind));
+		  getSendExtendedRtpCapabilities));
 
 		Transport::SetHandler(this->sendHandler.get());
 	}
@@ -233,7 +222,7 @@ namespace mediasoupclient
 		{
 			this->sendHandler->StopSending(sendResult.localId);
 
-			throw;
+			throw error;
 		}
 
 		auto* producer = new Producer(
@@ -380,9 +369,10 @@ namespace mediasoupclient
 	  const json& dtlsParameters,
 	  const json& sctpParameters,
 	  const PeerConnection::Options* peerConnectionOptions,
-	  const json* extendedRtpCapabilities,
+	  const json* recvRtpCapabilities,
 	  const json& appData)
-	  : Transport(listener, id, extendedRtpCapabilities, appData)
+	  : Transport(listener, id, appData)
+	  , recvRtpCapabilities(recvRtpCapabilities)
 	{
 		MSC_TRACE();
 
@@ -424,7 +414,7 @@ namespace mediasoupclient
 			MSC_THROW_TYPE_ERROR("missing rtpParameters");
 		else if (!appData.is_object())
 			MSC_THROW_TYPE_ERROR("appData must be a JSON object");
-		else if (!ortc::canReceive(*rtpParameters, *this->extendedRtpCapabilities))
+		else if (!ortc::canReceive(*rtpParameters, *this->recvRtpCapabilities))
 			MSC_THROW_UNSUPPORTED_ERROR("cannot consume this Producer");
 
 		// May throw.

--- a/src/mediasoupclient.cpp
+++ b/src/mediasoupclient.cpp
@@ -3,11 +3,8 @@
 #include "mediasoupclient.hpp"
 #include "Logger.hpp"
 #include "version.hpp"
-#include <rtc_base/helpers.h>
 #include <rtc_base/ssl_adapter.h>
-#include <rtc_base/time_utils.h>
 #include <sstream>
-#include <system_wrappers/include/field_trial.h>
 
 namespace mediasoupclient
 {
@@ -17,17 +14,14 @@ namespace mediasoupclient
 
 		MSC_DEBUG("mediasoupclient v%s", Version().c_str());
 
-		webrtc::field_trial::InitFieldTrialsFromString("WebRTC-SupportVP9SVC/EnabledByFlag_3SL3TL/");
-
-		rtc::InitializeSSL();
-		rtc::InitRandom(rtc::Time());
+		webrtc::InitializeSSL();
 	}
 
 	void Cleanup() // NOLINT(readability-identifier-naming)
 	{
 		MSC_TRACE();
 
-		rtc::CleanupSSL();
+		webrtc::CleanupSSL();
 	}
 
 	std::string Version() // NOLINT(readability-identifier-naming)

--- a/src/ortc.cpp
+++ b/src/ortc.cpp
@@ -1565,7 +1565,7 @@ namespace mediasoupclient
         codecs.begin(),
         codecs.end(),
         [&firstMediaCodec](const json& codec)
-        { return codec["remotePayloadType"] == firstMediaCodec["payloadType"]; });
+        { return codec["preferredPayloadType"] == firstMediaCodec["payloadType"]; });
 
 			return codecIt != codecs.end();
 		}
@@ -1587,7 +1587,7 @@ namespace mediasoupclient
 			// Otherwise look for a compatible set of codecs.
 			else
 			{
-				for (int idx = 0; idx < codecs.size(); ++idx)
+				for (size_t idx = 0; idx < codecs.size(); ++idx)
 				{
 					if (matchCodecs(codecs[idx], const_cast<json&>(*capCodec), /*strict*/ true))
 					{
@@ -1660,8 +1660,8 @@ static bool matchCodecs(json& aCodec, json& bCodec, bool strict, bool modify)
 			if (aPacketizationMode != bPacketizationMode)
 				return false;
 
-			cricket::CodecParameterMap aParameters;
-			cricket::CodecParameterMap bParameters;
+			webrtc::CodecParameterMap aParameters;
+			webrtc::CodecParameterMap bParameters;
 
 			aParameters["level-asymmetry-allowed"] = std::to_string(getH264LevelAssimetryAllowed(aCodec));
 			aParameters["packetization-mode"]      = std::to_string(aPacketizationMode);
@@ -1673,7 +1673,7 @@ static bool matchCodecs(json& aCodec, json& bCodec, bool strict, bool modify)
 			if (!webrtc::H264IsSameProfile(aParameters, bParameters))
 				return false;
 
-			cricket::CodecParameterMap newParameters;
+			webrtc::CodecParameterMap newParameters;
 
 			try
 			{

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -80,8 +80,5 @@ add_subdirectory(deps/libwebrtc "${CMAKE_CURRENT_BINARY_DIR}/libwebrtc")
 # Public (interface) dependencies.
 target_link_libraries(test_mediasoupclient PUBLIC
 	webrtc
-	${LIBWEBRTC_BINARY_PATH}/api/video_codecs/libbuiltin_video_encoder_factory${CMAKE_STATIC_LIBRARY_SUFFIX}
-	${LIBWEBRTC_BINARY_PATH}/api/video_codecs/libbuiltin_video_decoder_factory${CMAKE_STATIC_LIBRARY_SUFFIX}
-	${LIBWEBRTC_BINARY_PATH}/media/librtc_simulcast_encoder_adapter${CMAKE_STATIC_LIBRARY_SUFFIX}
-	${LIBWEBRTC_BINARY_PATH}/media/librtc_internal_video_codecs${CMAKE_STATIC_LIBRARY_SUFFIX}
+	${LIBWEBRTC_BINARY_PATH}/libwebrtc${CMAKE_STATIC_LIBRARY_SUFFIX}
 )

--- a/test/deps/libwebrtc/pc/test/fake_audio_capture_module.cc
+++ b/test/deps/libwebrtc/pc/test/fake_audio_capture_module.cc
@@ -52,8 +52,8 @@ FakeAudioCaptureModule::~FakeAudioCaptureModule() {
   }
 }
 
-rtc::scoped_refptr<FakeAudioCaptureModule> FakeAudioCaptureModule::Create() {
-  auto capture_module = rtc::make_ref_counted<FakeAudioCaptureModule>();
+webrtc::scoped_refptr<FakeAudioCaptureModule> FakeAudioCaptureModule::Create() {
+  auto capture_module = webrtc::make_ref_counted<FakeAudioCaptureModule>();
   if (!capture_module->Initialize()) {
     return nullptr;
   }
@@ -421,7 +421,7 @@ bool FakeAudioCaptureModule::ShouldStartProcessing() {
 void FakeAudioCaptureModule::UpdateProcessing(bool start) {
   if (start) {
     if (!process_thread_) {
-      process_thread_ = rtc::Thread::Create();
+      process_thread_ = webrtc::Thread::Create();
       process_thread_->Start();
     }
     process_thread_->PostTask([this] { StartProcessP(); });
@@ -453,7 +453,7 @@ void FakeAudioCaptureModule::ProcessFrameP() {
   {
     webrtc::MutexLock lock(&mutex_);
     if (!started_) {
-      next_frame_time_ = rtc::TimeMillis();
+      next_frame_time_ = webrtc::TimeMillis();
       started_ = true;
     }
 
@@ -467,7 +467,7 @@ void FakeAudioCaptureModule::ProcessFrameP() {
   }
 
   next_frame_time_ += kTimePerFrameMs;
-  const int64_t current_time = rtc::TimeMillis();
+  const int64_t current_time = webrtc::TimeMillis();
   const int64_t wait_time =
       (next_frame_time_ > current_time) ? next_frame_time_ - current_time : 0;
   process_thread_->PostDelayedTask([this] { ProcessFrameP(); },

--- a/test/deps/libwebrtc/pc/test/fake_audio_capture_module.h
+++ b/test/deps/libwebrtc/pc/test/fake_audio_capture_module.h
@@ -46,7 +46,7 @@ class FakeAudioCaptureModule : public webrtc::AudioDeviceModule {
   static const size_t kNumberBytesPerSample = sizeof(Sample);
 
   // Creates a FakeAudioCaptureModule or returns NULL on failure.
-  static rtc::scoped_refptr<FakeAudioCaptureModule> Create();
+  static webrtc::scoped_refptr<FakeAudioCaptureModule> Create();
 
   // Returns the number of frames that have been successfully pulled by the
   // instance. Note that correctly detecting success can only be done if the
@@ -214,7 +214,7 @@ class FakeAudioCaptureModule : public webrtc::AudioDeviceModule {
   bool started_ RTC_GUARDED_BY(mutex_);
   int64_t next_frame_time_ RTC_GUARDED_BY(process_thread_checker_);
 
-  std::unique_ptr<rtc::Thread> process_thread_;
+  std::unique_ptr<webrtc::Thread> process_thread_;
 
   // Buffer for storing samples received from the webrtc::AudioTransport.
   char rec_buffer_[kNumberSamples * kNumberBytesPerSample];

--- a/test/include/MediaStreamTrackFactory.hpp
+++ b/test/include/MediaStreamTrackFactory.hpp
@@ -30,7 +30,7 @@ public:
 
 	void ReleaseThreads();
 
-	rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> Factory;
+	webrtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> Factory;
 	mediasoupclient::PeerConnection::Options PeerConnectionOptions;
 
 private:
@@ -47,13 +47,13 @@ private:
 	 * MediaStreamTrack holds reference to the threads of the PeerConnectionFactory.
 	 * Use plain pointers in order to avoid threads being destructed before tracks.
 	 */
-	std::unique_ptr<rtc::Thread> NetworkThread;
-	std::unique_ptr<rtc::Thread> WorkerThread;
-	std::unique_ptr<rtc::Thread> SignalingThread;
+	std::unique_ptr<webrtc::Thread> NetworkThread;
+	std::unique_ptr<webrtc::Thread> WorkerThread;
+	std::unique_ptr<webrtc::Thread> SignalingThread;
 };
 
-rtc::scoped_refptr<webrtc::AudioTrackInterface> createAudioTrack(const std::string& label);
+webrtc::scoped_refptr<webrtc::AudioTrackInterface> createAudioTrack(const std::string& label);
 
-rtc::scoped_refptr<webrtc::VideoTrackInterface> createVideoTrack(const std::string& label);
+webrtc::scoped_refptr<webrtc::VideoTrackInterface> createVideoTrack(const std::string& label);
 
 #endif

--- a/test/src/Handler.test.cpp
+++ b/test/src/Handler.test.cpp
@@ -2,12 +2,18 @@
 #include "MediaSoupClientErrors.hpp"
 #include "MediaStreamTrackFactory.hpp"
 #include "fakeParameters.hpp"
+#include "ortc.hpp"
 #include <catch.hpp>
 #include <iostream>
 #include <memory>
 
 static const json TransportRemoteParameters = generateTransportRemoteParameters();
 static const json RtpParametersByKind       = generateRtpParametersByKind();
+static const json RouterRtpCapabilities     = generateRouterRtpCapabilities();
+static const auto getSendCapabilities       = [](json& currentLocalRtpCapabilities) {
+			auto routerRtpCapabilitiesCopy = RouterRtpCapabilities;
+			return mediasoupclient::ortc::getExtendedRtpCapabilities(currentLocalRtpCapabilities, routerRtpCapabilitiesCopy);
+		};
 
 class FakeHandlerListener : public mediasoupclient::Handler::PrivateListener
 {
@@ -47,8 +53,7 @@ TEST_CASE("SendHandler", "[Handler][SendHandler]")
 	  TransportRemoteParameters["dtlsParameters"],
 	  TransportRemoteParameters["sctpParameters"],
 	  &singleton.PeerConnectionOptions,
-	  RtpParametersByKind,
-	  RtpParametersByKind);
+	  getSendCapabilities);
 
 	static webrtc::scoped_refptr<webrtc::AudioTrackInterface> track;
 

--- a/test/src/Handler.test.cpp
+++ b/test/src/Handler.test.cpp
@@ -50,7 +50,7 @@ TEST_CASE("SendHandler", "[Handler][SendHandler]")
 	  RtpParametersByKind,
 	  RtpParametersByKind);
 
-	static rtc::scoped_refptr<webrtc::AudioTrackInterface> track;
+	static webrtc::scoped_refptr<webrtc::AudioTrackInterface> track;
 
 	static std::string localId;
 

--- a/test/src/MediaStreamTrackFactory.cpp
+++ b/test/src/MediaStreamTrackFactory.cpp
@@ -21,9 +21,9 @@ void MediaStreamTrackFactory::Create()
 {
 	if (Factory)
 		return;
-	NetworkThread   = rtc::Thread::CreateWithSocketServer();
-	WorkerThread    = rtc::Thread::Create();
-	SignalingThread = rtc::Thread::Create();
+	NetworkThread   = webrtc::Thread::CreateWithSocketServer();
+	WorkerThread    = webrtc::Thread::Create();
+	SignalingThread = webrtc::Thread::Create();
 
 	NetworkThread->SetName("network_thread", nullptr);
 	SignalingThread->SetName("signaling_thread", nullptr);
@@ -92,25 +92,25 @@ void MediaStreamTrackFactory::ReleaseThreads()
 }
 
 // Audio track creation.
-rtc::scoped_refptr<webrtc::AudioTrackInterface> createAudioTrack(const std::string& label)
+webrtc::scoped_refptr<webrtc::AudioTrackInterface> createAudioTrack(const std::string& label)
 {
 	MediaStreamTrackFactory& singleton = MediaStreamTrackFactory::getInstance();
 
-	cricket::AudioOptions options;
+	webrtc::AudioOptions options;
 	options.highpass_filter = false;
 
-	rtc::scoped_refptr<webrtc::AudioSourceInterface> source =
+	webrtc::scoped_refptr<webrtc::AudioSourceInterface> source =
 	  singleton.Factory->CreateAudioSource(options);
 
 	return singleton.Factory->CreateAudioTrack(label, source.get());
 }
 
 // Video track creation.
-rtc::scoped_refptr<webrtc::VideoTrackInterface> createVideoTrack(const std::string& label)
+webrtc::scoped_refptr<webrtc::VideoTrackInterface> createVideoTrack(const std::string& label)
 {
 	MediaStreamTrackFactory& singleton = MediaStreamTrackFactory::getInstance();
 
-	rtc::scoped_refptr<webrtc::FakeVideoTrackSource> source = webrtc::FakeVideoTrackSource::Create();
+	webrtc::scoped_refptr<webrtc::FakeVideoTrackSource> source = webrtc::FakeVideoTrackSource::Create();
 
 	return singleton.Factory->CreateVideoTrack(source, label);
 }

--- a/test/src/PeerConnection.test.cpp
+++ b/test/src/PeerConnection.test.cpp
@@ -60,7 +60,7 @@ TEST_CASE("PeerConnection", "[PeerConnection]")
 		auto sdp = std::string();
 
 		REQUIRE_THROWS_AS(
-		  pc.SetLocalDescription(mediasoupclient::webrtc::SdpType::kOffer, sdp),
+		  pc.SetLocalDescription(webrtc::SdpType::kOffer, sdp),
 		  MediaSoupClientError);
 	}
 
@@ -68,7 +68,7 @@ TEST_CASE("PeerConnection", "[PeerConnection]")
 	{
 		auto sdp = helpers::readFile("test/data/webrtc.sdp");
 
-		REQUIRE_NOTHROW(pc.SetRemoteDescription(mediasoupclient::webrtc::SdpType::kOffer, sdp));
+		REQUIRE_NOTHROW(pc.SetRemoteDescription(webrtc::SdpType::kOffer, sdp));
 	}
 
 	SECTION("'pc.CreateOffer()' succeeds")
@@ -80,7 +80,7 @@ TEST_CASE("PeerConnection", "[PeerConnection]")
 
 	SECTION("'pc.SetRemoteDescription()' succeeds")
 	{
-		REQUIRE_NOTHROW(pc.SetRemoteDescription(mediasoupclient::webrtc::SdpType::kOffer, offer));
+		REQUIRE_NOTHROW(pc.SetRemoteDescription(webrtc::SdpType::kOffer, offer));
 	}
 
 	SECTION("'pc.CreateAnswer()' succeeds if remote offer is provided")

--- a/test/src/PeerConnection.test.cpp
+++ b/test/src/PeerConnection.test.cpp
@@ -60,7 +60,7 @@ TEST_CASE("PeerConnection", "[PeerConnection]")
 		auto sdp = std::string();
 
 		REQUIRE_THROWS_AS(
-		  pc.SetLocalDescription(mediasoupclient::PeerConnection::SdpType::OFFER, sdp),
+		  pc.SetLocalDescription(mediasoupclient::webrtc::SdpType::kOffer, sdp),
 		  MediaSoupClientError);
 	}
 
@@ -68,7 +68,7 @@ TEST_CASE("PeerConnection", "[PeerConnection]")
 	{
 		auto sdp = helpers::readFile("test/data/webrtc.sdp");
 
-		REQUIRE_NOTHROW(pc.SetRemoteDescription(mediasoupclient::PeerConnection::SdpType::OFFER, sdp));
+		REQUIRE_NOTHROW(pc.SetRemoteDescription(mediasoupclient::webrtc::SdpType::kOffer, sdp));
 	}
 
 	SECTION("'pc.CreateOffer()' succeeds")
@@ -80,7 +80,7 @@ TEST_CASE("PeerConnection", "[PeerConnection]")
 
 	SECTION("'pc.SetRemoteDescription()' succeeds")
 	{
-		REQUIRE_NOTHROW(pc.SetRemoteDescription(mediasoupclient::PeerConnection::SdpType::OFFER, offer));
+		REQUIRE_NOTHROW(pc.SetRemoteDescription(mediasoupclient::webrtc::SdpType::kOffer, offer));
 	}
 
 	SECTION("'pc.CreateAnswer()' succeeds if remote offer is provided")

--- a/test/src/mediasoupclient.test.cpp
+++ b/test/src/mediasoupclient.test.cpp
@@ -27,8 +27,8 @@ TEST_CASE("mediasoupclient", "[mediasoupclient]")
 	static std::unique_ptr<mediasoupclient::DataProducer> dataProducer;
 	static std::unique_ptr<mediasoupclient::DataConsumer> dataConsumer;
 
-	static rtc::scoped_refptr<webrtc::AudioTrackInterface> audioTrack;
-	static rtc::scoped_refptr<webrtc::VideoTrackInterface> videoTrack;
+	static webrtc::scoped_refptr<webrtc::AudioTrackInterface> audioTrack;
+	static webrtc::scoped_refptr<webrtc::VideoTrackInterface> videoTrack;
 
 	static FakeProducerListener producerListener;
 	static FakeConsumerListener consumerListener;

--- a/test/src/ortc.test.cpp
+++ b/test/src/ortc.test.cpp
@@ -163,8 +163,7 @@ TEST_CASE("ortc::canReceive", "[ortc::canReceive]")
 {
 	json remoteCaps = generateRouterRtpCapabilities();
 	json localCaps  = generateRouterRtpCapabilities();
-
-	auto extendedRtpCapabilities = ortc::getExtendedRtpCapabilities(localCaps, remoteCaps);
+	auto extendedRtpCapabilities = ortc::getRecvRtpCapabilities(ortc::getExtendedRtpCapabilities(localCaps, remoteCaps));
 
 	SECTION("it can receive")
 	{
@@ -186,6 +185,7 @@ TEST_CASE("ortc::canReceive", "[ortc::canReceive]")
 				}
 			]
 		})"_json;
+
 
 		REQUIRE(ortc::canReceive(rtpParameters, extendedRtpCapabilities));
 	}

--- a/test/src/tests.cpp
+++ b/test/src/tests.cpp
@@ -9,7 +9,7 @@
 int main(int argc, char* argv[])
 {
 	mediasoupclient::Logger::LogLevel logLevel{ mediasoupclient::Logger::LogLevel::LOG_NONE };
-	rtc::LoggingSeverity webrtcLogLevel{ rtc::LoggingSeverity::LS_NONE };
+	webrtc::LoggingSeverity webrtcLogLevel{ webrtc::LoggingSeverity::LS_NONE };
 	Catch::Session session;
 	std::string logLevelStr;
 	std::string webrtcLogLevelStr;
@@ -40,18 +40,18 @@ int main(int argc, char* argv[])
 		logLevel = mediasoupclient::Logger::LogLevel::LOG_ERROR;
 
 	if (webrtcLogLevelStr == "verbose")
-		webrtcLogLevel = rtc::LoggingSeverity::LS_VERBOSE;
+		webrtcLogLevel = webrtc::LoggingSeverity::LS_VERBOSE;
 	else if (webrtcLogLevelStr == "info")
-		webrtcLogLevel = rtc::LoggingSeverity::LS_INFO;
+		webrtcLogLevel = webrtc::LoggingSeverity::LS_INFO;
 	else if (webrtcLogLevelStr == "warn")
-		webrtcLogLevel = rtc::LoggingSeverity::LS_WARNING;
+		webrtcLogLevel = webrtc::LoggingSeverity::LS_WARNING;
 	else if (webrtcLogLevelStr == "error")
-		webrtcLogLevel = rtc::LoggingSeverity::LS_ERROR;
+		webrtcLogLevel = webrtc::LoggingSeverity::LS_ERROR;
 
 	mediasoupclient::Logger::SetLogLevel(logLevel);
 	mediasoupclient::Logger::SetHandler(new mediasoupclient::Logger::DefaultLogHandler());
 
-	rtc::LogMessage::LogToDebug(webrtcLogLevel);
+	webrtc::LogMessage::LogToDebug(webrtcLogLevel);
 
 	// Initialization.
 	mediasoupclient::Initialize();


### PR DESCRIPTION
note: this includes a similar fix as the PR336 (https://github.com/versatica/mediasoup-client/pull/336) from the mediasoup-client repo which deals with webrtc changes and expectations for payload-type/extension ids to stay consistent
note: some aestetics and clang-compile warnings have also been fixes, so it compiles using cpp20/clang20

I have to admit that no unit tests have been run, however, using it to produce/consume media works as expected in local tests.
This should also support M142, however, the latest I've tested the changes against is M140.

