### PR TITLE
Simple CLI demo for MacOs running agains mediasoup-demo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Project options.
 option(MEDIASOUPCLIENT_BUILD_TESTS "Build unit tests" OFF)
+option(MEDIASOUPCLIENT_BUILD_DEMO  "Build demo app" OFF)
 option(MEDIASOUPCLIENT_LOG_TRACE   "Enable MSC_LOG_TRACE (See Logger.hpp)" OFF)
 option(MEDIASOUPCLIENT_LOG_DEV     "Enable MSC_LOG_DEV (See Logger.hpp)" OFF)
 
@@ -43,6 +44,7 @@ endif()
 
 message("\n=========== libmediasoupclient Build Configuration ===========\n")
 message(STATUS "MEDIASOUPCLIENT_BUILD_TESTS : " ${MEDIASOUPCLIENT_BUILD_TESTS})
+message(STATUS "MEDIASOUPCLIENT_BUILD_DEMO  : " ${MEDIASOUPCLIENT_BUILD_DEMO})
 message(STATUS "MEDIASOUPCLIENT_LOG_TRACE   : " ${MEDIASOUPCLIENT_LOG_TRACE})
 message(STATUS "MEDIASOUPCLIENT_LOG_DEV     : " ${MEDIASOUPCLIENT_LOG_DEV})
 message(STATUS "LIBWEBRTC_INCLUDE_PATH      : " ${LIBWEBRTC_INCLUDE_PATH})
@@ -158,3 +160,7 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC
 
 install(TARGETS mediasoupclient DESTINATION lib)
 install(FILES ${HEADER_FILES} DESTINATION include/mediasoupclient)
+
+if (${MEDIASOUPCLIENT_BUILD_DEMO})
+	add_subdirectory(demo)
+endif()

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -1,0 +1,89 @@
+cmake_minimum_required(VERSION 3.14)
+
+include(FetchContent)
+
+# ixwebsocket — WebSocket client with TLS support
+message(STATUS "\nFetching ixwebsocket...\n")
+FetchContent_Declare(
+	ixwebsocket
+	GIT_REPOSITORY https://github.com/machinezone/IXWebSocket.git
+	GIT_TAG        v11.4.5
+)
+set(USE_TLS ON CACHE BOOL "Enable TLS in ixwebsocket" FORCE)
+FetchContent_MakeAvailable(ixwebsocket)
+
+# CLI11 — command-line argument parsing
+message(STATUS "\nFetching CLI11...\n")
+FetchContent_Declare(
+	cli11
+	GIT_REPOSITORY https://github.com/CLIUtils/CLI11.git
+	GIT_TAG        v2.4.2
+)
+FetchContent_MakeAvailable(cli11)
+
+add_executable(mediasoupclient_demo
+	include/AVFCaptureVideoSource.hpp
+	include/ProtooClient.hpp
+	include/RoomClient.hpp
+	src/AVFCaptureVideoSource.mm
+	src/ProtooClient.cpp
+	src/RoomClient.cpp
+	src/main.cpp
+)
+
+target_compile_definitions(mediasoupclient_demo PRIVATE
+	$<$<PLATFORM_ID:Windows>:NOMINMAX>
+	$<$<PLATFORM_ID:Windows>:WIN32_LEAN_AND_MEAN>
+	NDEBUG
+)
+
+target_include_directories(mediasoupclient_demo PRIVATE
+	include
+	${mediasoupclient_SOURCE_DIR}/include
+	${LIBWEBRTC_INCLUDE_PATH}/third_party/libyuv/include
+)
+
+if(APPLE)
+	find_library(APPLICATION_SERVICES ApplicationServices)
+	find_library(AUDIO_TOOLBOX AudioToolbox)
+	find_library(AVFOUNDATION AVFoundation)
+	find_library(CORE_AUDIO CoreAudio)
+	find_library(CORE_FOUNDATION Foundation)
+	find_library(CORE_MEDIA CoreMedia)
+	find_library(CORE_VIDEO CoreVideo)
+	find_library(SECURITY Security)
+
+	target_link_libraries(mediasoupclient_demo PRIVATE
+		${APPLICATION_SERVICES}
+		${AUDIO_TOOLBOX}
+		${AVFOUNDATION}
+		${CORE_AUDIO}
+		${CORE_FOUNDATION}
+		${CORE_MEDIA}
+		${CORE_VIDEO}
+		${SECURITY}
+	)
+
+	set_target_properties(mediasoupclient_demo PROPERTIES
+		MACOSX_BUNDLE TRUE
+		MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist
+	)
+endif()
+
+if(UNIX)
+	find_package(Threads REQUIRED)
+	target_link_libraries(mediasoupclient_demo PRIVATE Threads::Threads)
+endif()
+
+target_link_libraries(mediasoupclient_demo PRIVATE
+	mediasoupclient
+	ixwebsocket
+	CLI11::CLI11
+	${CMAKE_DL_LIBS}
+)
+
+# libwebrtc is added after add_subdirectory in the parent scope,
+# so we link it explicitly here.
+target_link_libraries(mediasoupclient_demo PUBLIC
+	${LIBWEBRTC_BINARY_PATH}/libwebrtc${CMAKE_STATIC_LIBRARY_SUFFIX}
+)

--- a/demo/Info.plist
+++ b/demo/Info.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>net.jssip.mediasoupclient-demo</string>
+  <key>CFBundleName</key>
+  <string>mediasoupclient-demo</string>
+  <key>CFBundleVersion</key>
+  <string>1.0</string>
+  <key>NSCameraUsageDescription</key>
+  <string>mediasoupclient demo needs camera access to send video.</string>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>mediasoupclient demo needs microphone access to send audio.</string>
+</dict>
+</plist>

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,60 @@
+# mediasoupclient demo
+
+Connects to a [mediasoup-demo](https://github.com/versatica/mediasoup-demo) server, sends mic audio and camera video, and receives audio/video from other participants.
+
+## Prerequisites
+
+- CMake ≥ 3.14 and a C++20-capable compiler.
+- Optionally, a running mediasoup-demo server.
+
+## Build & Run
+
+`run.sh` always does an incremental build before launching the binary.
+Pass `rebuild` as the first argument to do a full clean reconfigure first.
+
+```bash
+# Incremental build + run
+PATH_TO_LIBWEBRTC_SOURCES=/path/to/libwebrtc/src \
+PATH_TO_LIBWEBRTC_BINARY=/path/to/libwebrtc/out/Release \
+./demo/run.sh --url wss://<server>:4443 --origin https://<server>:4443
+
+# Full clean reconfigure + build + run
+PATH_TO_LIBWEBRTC_SOURCES=/path/to/libwebrtc/src \
+PATH_TO_LIBWEBRTC_BINARY=/path/to/libwebrtc/out/Release \
+./demo/run.sh rebuild --url wss://<server>:4443 --origin https://<server>:4443
+```
+
+### Manual build
+
+```bash
+cmake . -Bbuild \
+  -DLIBWEBRTC_INCLUDE_PATH=/path/to/libwebrtc/src \
+  -DLIBWEBRTC_BINARY_PATH=/path/to/libwebrtc/out/Release \
+  -DMEDIASOUPCLIENT_BUILD_DEMO=ON
+
+cmake --build build --target mediasoupclient_demo
+```
+
+Then run the binary directly (macOS bundle path shown; Linux omits `.app/Contents/MacOS`):
+
+```bash
+./build/demo/mediasoupclient_demo.app/Contents/MacOS/mediasoupclient_demo \
+  --url    wss://<server>:4443 \
+  --origin https://<server>:4443
+```
+
+Pass `--help` for a full list of options.
+
+## Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--ws-url` | *(required)* | Protoo WebSocket URL, e.g. `wss://localhost:4443` |
+| `--origin` | *(required)* | HTTP Origin header sent during the WebSocket handshake |
+| `--room-id` | `demo-room` | Room ID to join |
+
+## Example: connect to official mediasoup demo
+
+```bash
+ ./run.sh --ws-url wss://v3demo.mediasoup.org:4443 --origin https://v3demo.mediasoup.org --room-id foobar
+```

--- a/demo/include/AVFCaptureVideoSource.hpp
+++ b/demo/include/AVFCaptureVideoSource.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "media/base/video_broadcaster.h"
+#include "pc/video_track_source.h"
+
+/**
+ * VideoTrackSource backed by a real macOS camera via AVFoundation.
+ * The ObjC capture session lives in AVFCaptureVideoSource.mm.
+ */
+class AVFCaptureVideoSource : public webrtc::VideoTrackSource
+{
+public:
+	static webrtc::scoped_refptr<AVFCaptureVideoSource> Create(int width, int height, int fps);
+
+	explicit AVFCaptureVideoSource();
+	~AVFCaptureVideoSource() override;
+
+	webrtc::VideoSourceInterface<webrtc::VideoFrame>* source() override;
+
+protected:
+	void AddOrUpdateSink(
+	  webrtc::VideoSinkInterface<webrtc::VideoFrame>* sink,
+	  const webrtc::VideoSinkWants& wants) override;
+
+	void RemoveSink(webrtc::VideoSinkInterface<webrtc::VideoFrame>* sink) override;
+
+private:
+	webrtc::VideoBroadcaster broadcaster;
+	void* impl{ nullptr }; // opaque pointer to ObjC AVFCaptureImpl
+};

--- a/demo/include/ProtooClient.hpp
+++ b/demo/include/ProtooClient.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <functional>
+#include <future>
+#include <ixwebsocket/IXWebSocket.h>
+#include <json.hpp>
+#include <map>
+#include <mutex>
+#include <string>
+
+using json = nlohmann::json;
+
+/**
+ * Minimal Protoo WebSocket client.
+ *
+ * Protocol:
+ *   Request:      { "request": true,  "id": N, "method": "...", "data": {} }
+ *   Response OK:  { "response": true, "id": N, "ok": true, "data": {} }
+ *   Response ERR: { "response": true, "id": N, "ok": false, "errorReason": "..." }
+ *   Notification: { "notification": true, "method": "...", "data": {} }
+ */
+class ProtooClient
+{
+public:
+	using NotificationCallback = std::function<void(const std::string& method, const json& data)>;
+	using RequestCallback =
+	  std::function<void(const std::string& method, const json& data, json& responseData)>;
+
+	explicit ProtooClient(
+	  const std::string& url,
+	  const std::string& origin,
+	  NotificationCallback notificationCb,
+	  RequestCallback requestCb);
+
+	void Connect(int timeoutMs = 5000);
+	void Close();
+
+	// Send a Protoo request and block until the response arrives.
+	json Request(const std::string& method, const json& data = json::object());
+
+private:
+	void OnMessage(const std::string& str);
+
+	ix::WebSocket ws;
+
+	// Atomic: incremented from Request() on any calling thread.
+	std::atomic<int> nextId{ 1 };
+
+	// Guards connected/connectError: written by the ixwebsocket callback thread,
+	// read by Connect() on the calling thread.
+	std::mutex connMutex;
+	std::condition_variable connCv;
+	bool connected{ false };
+	std::string connectError;
+
+	// Guards pending: Request() (any thread) inserts, OnMessage() (ixwebsocket
+	// thread) finds and erases — concurrent access to std::map requires a lock.
+	std::mutex pendingMutex;
+	std::map<int, std::promise<json>> pending;
+
+	NotificationCallback notificationCb;
+	RequestCallback requestCb;
+};

--- a/demo/include/RoomClient.hpp
+++ b/demo/include/RoomClient.hpp
@@ -1,0 +1,218 @@
+#pragma once
+
+#include "ProtooClient.hpp"
+#include "mediasoupclient.hpp"
+#include <api/media_stream_interface.h> // webrtc::VideoTrackInterface
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+/**
+ * RoomClient
+ *
+ * Wraps a ProtooClient WebSocket connection and a mediasoupclient Device to
+ * implement the full mediasoup-demo room protocol:
+ *
+ *   - Loads the Device from the router's RTP capabilities.
+ *   - Creates a bidirectional pair of WebRTC transports (send + recv).
+ *   - Joins the room and handles server-initiated newConsumer / newDataConsumer
+ *     requests as well as peerClosed / newPeer notifications.
+ *   - Exposes simple enable/disable methods for mic, camera, and data chat.
+ *
+ * Caller wires up the three std::function callbacks before calling join().
+ */
+class RoomClient
+{
+public:
+	// -------------------------------------------------------------------------
+	// Public interface
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @param url             Full Protoo WebSocket URL, e.g.
+	 *                        "wss://host:4443/?roomId=r&peerId=p"
+	 * @param origin          HTTP Origin header sent during the WS handshake.
+	 * @param displayName     Display name announced to the room on join().
+	 * @param factory         PeerConnectionFactory used for all transports.
+	 *                        Stored as a raw pointer — caller must keep it alive.
+	 * @param pcOptions       Additional PeerConnection options (ICE servers, etc.).
+	 *                        pcOptions.factory is overwritten by @p factory.
+	 * @param onNewVideoTrack Called when a remote video track becomes available
+	 *                        (newConsumer for kind=="video").
+	 * @param onPeerLeft      Called when a peer leaves the room (peerClosed).
+	 * @param onDataMessage   Called when a DataConsumer message is received.
+	 */
+	RoomClient(
+	  const std::string& url,
+	  const std::string& origin,
+	  const std::string& displayName,
+	  webrtc::PeerConnectionFactoryInterface* factory,
+	  mediasoupclient::PeerConnection::Options pcOptions,
+	  std::function<void(const std::string& peerId, webrtc::VideoTrackInterface*)> onNewVideoTrack,
+	  std::function<void(const std::string& peerId)> onPeerLeft,
+	  std::function<void(const std::string& message)> onDataMessage);
+
+	~RoomClient();
+
+	// Non-copyable, non-movable (owns raw transport/producer pointers).
+	RoomClient(const RoomClient&)            = delete;
+	RoomClient& operator=(const RoomClient&) = delete;
+	RoomClient(RoomClient&&)                 = delete;
+	RoomClient& operator=(RoomClient&&)      = delete;
+
+	/**
+	 * Connect to the Protoo server, load the Device, create transports, and
+	 * send the "join" request.  Blocks until the join completes or throws on
+	 * failure.  Call this once after setting the callbacks.
+	 */
+	void Join();
+
+	/**
+	 * Gracefully close all producers, consumers, transports, and the Protoo
+	 * connection.  Safe to call more than once.
+	 */
+	void Close();
+
+	/** Create an audio producer from the platform microphone. */
+	void EnableMic();
+
+	/** Close and destroy the current mic producer. */
+	void DisableMic();
+
+	/**
+	 * Create a video producer from the supplied track.
+	 * @param videoTrack A VideoTrackInterface obtained from the factory or a
+	 *                   platform capture source (e.g. AVFCaptureVideoSource).
+	 */
+	void EnableCamera(webrtc::scoped_refptr<webrtc::VideoTrackInterface> videoTrack);
+
+	/** Close and destroy the current camera producer. */
+	void DisableCamera();
+
+	/**
+	 * Open a DataProducer on the send transport labelled "chat" with
+	 * protocol "text/plain".  Messages from peers arrive via onDataMessage.
+	 */
+	void EnableChat();
+
+private:
+	// -------------------------------------------------------------------------
+	// Private nested listener classes — full definitions live in RoomClient.cpp
+	// -------------------------------------------------------------------------
+
+	/** Handles send-transport signaling (connectWebRtcTransport + produce +
+	 *  produceData) by forwarding to the Protoo request channel. */
+	class SendTransportListener;
+
+	/** Handles recv-transport signaling (connectWebRtcTransport). */
+	class RecvTransportListener;
+
+	/** Minimal Producer::Listener — only logs transport-close events. */
+	class ProducerListener;
+
+	/** Minimal Consumer::Listener — only logs transport-close events. */
+	class ConsumerListener;
+
+	/** Minimal DataProducer::Listener — forwards open/close/error. */
+	class DataProducerListener;
+
+	/**
+	 * DataConsumer::Listener — delivers incoming messages to onDataMessage
+	 * and handles state-change events.
+	 */
+	class DataConsumerListener;
+
+	// -------------------------------------------------------------------------
+	// Per-peer state
+	// -------------------------------------------------------------------------
+
+	struct Participant
+	{
+		mediasoupclient::Consumer* audioConsumer{ nullptr };
+		mediasoupclient::Consumer* videoConsumer{ nullptr };
+	};
+
+	// -------------------------------------------------------------------------
+	// Private helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Dispatched by ProtooClient for server-initiated requests such as
+	 * "newConsumer" and "newDataConsumer".  Fills @p responseData and may
+	 * throw on error (ProtooClient will send the appropriate error response).
+	 */
+	void HandleRequest(const std::string& method, const json& data, json& responseData);
+
+	/**
+	 * Dispatched by ProtooClient for server push notifications such as
+	 * "newPeer" and "peerClosed".
+	 */
+	void HandleNotification(const std::string& method, const json& data);
+
+	// -------------------------------------------------------------------------
+	// Data members
+	// -------------------------------------------------------------------------
+
+	// Protoo WebSocket client.
+	ProtooClient protoo;
+
+	// mediasoupclient Device — loaded with router RTP capabilities on join().
+	mediasoupclient::Device device;
+
+	// WebRTC transports — created during join(), owned by this class.
+	mediasoupclient::SendTransport* sendTransport{ nullptr };
+	mediasoupclient::RecvTransport* recvTransport{ nullptr };
+
+	// Active producers — nullptr when the respective source is disabled.
+	mediasoupclient::Producer* micProducer{ nullptr };
+	mediasoupclient::Producer* cameraProducer{ nullptr };
+	mediasoupclient::DataProducer* chatDataProducer{ nullptr };
+
+	// Transport / producer / consumer listener singletons.
+	// Defined as unique_ptr so that their full types only need to be visible
+	// in RoomClient.cpp (incomplete-type friendly destruction).
+	std::unique_ptr<SendTransportListener> sendListener;
+	std::unique_ptr<RecvTransportListener> recvListener;
+	std::unique_ptr<ConsumerListener> consumerListener;
+	std::unique_ptr<ProducerListener> producerListener;
+	std::unique_ptr<DataProducerListener> dataProducerListener;
+	std::unique_ptr<DataConsumerListener> dataConsumerListener;
+
+	// Remote participants — keyed by Protoo peerId.
+	std::map<std::string, Participant> participants;
+
+	// Guards participants: HandleRequest() runs on a dispatch worker thread,
+	// HandleNotification() on the ixwebsocket receive thread, and Close() on
+	// the main thread — all three can access participants concurrently.
+	std::mutex participantsMutex;
+
+	// Serialises HandleRequest() calls: multiple newConsumer/newDataConsumer
+	// requests can arrive in quick succession and are each dispatched to a
+	// separate worker thread by ProtooClient. Without serialisation both threads
+	// can enter Consume() before the transport is marked ready, causing a second
+	// connectWebRtcTransport call that the server rejects with "already called".
+	std::mutex handleRequestMutex;
+
+	// All active DataConsumers (owned by this class).
+	std::vector<mediasoupclient::DataConsumer*> dataConsumers;
+
+	// PeerConnection factory — not owned; caller must keep it alive.
+	webrtc::PeerConnectionFactoryInterface* factory{ nullptr };
+
+	// PeerConnection options forwarded to Device::Create*Transport().
+	mediasoupclient::PeerConnection::Options pcOptions;
+
+	// Display name announced to the room.
+	std::string displayName;
+
+	// Application callbacks.
+	std::function<void(const std::string& peerId, webrtc::VideoTrackInterface*)> onNewVideoTrack;
+	std::function<void(const std::string& peerId)> onPeerLeft;
+	std::function<void(const std::string& message)> onDataMessage;
+
+	// Set to true after close() is called to prevent double-close.
+	bool closed{ false };
+};

--- a/demo/run.sh
+++ b/demo/run.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Always run from the project root (parent of the demo/ directory).
+cd "$(dirname "$0")/..";
+OS="$(uname -s)"
+
+# Resolve the demo binary path.
+if [ "${OS}" = "Darwin" ]; then
+	DEMO_BINARY=./build/demo/mediasoupclient_demo.app/Contents/MacOS/mediasoupclient_demo
+else
+	DEMO_BINARY=./build/demo/mediasoupclient_demo
+fi
+
+# --help: forward directly to the binary (no build needed).
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+	if [ -f "${DEMO_BINARY}" ]; then
+		exec "${DEMO_BINARY}" --help
+	fi
+	echo "Usage: $(basename $0) [rebuild] [serverUrl] [origin]"
+	echo "       $(basename $0) --help"
+	exit 0
+fi
+
+# rebuild: clean + reconfigure.
+if [ "$1" = "rebuild" ]; then
+	echo "[INFO] rebuilding: cmake . -Bbuild [...]"
+	rm -rf build/
+	cmake . -Bbuild \
+		-DLIBWEBRTC_INCLUDE_PATH:PATH=${PATH_TO_LIBWEBRTC_SOURCES} \
+		-DLIBWEBRTC_BINARY_PATH:PATH=${PATH_TO_LIBWEBRTC_BINARY} \
+		-DMEDIASOUPCLIENT_BUILD_DEMO="true" \
+		-DCMAKE_CXX_FLAGS="-fvisibility=hidden" \
+		-DCMAKE_POLICY_VERSION_MINIMUM=3.5
+	shift
+fi
+
+echo "[INFO] compiling: cmake --build build --target mediasoupclient_demo"
+cmake --build build --target mediasoupclient_demo
+
+echo "[INFO] running: ${DEMO_BINARY} $@"
+exec "${DEMO_BINARY}" "$@"

--- a/demo/src/AVFCaptureVideoSource.mm
+++ b/demo/src/AVFCaptureVideoSource.mm
@@ -1,0 +1,261 @@
+/**
+ * AVFCaptureVideoSource.mm — macOS camera capture via AVFoundation.
+ * Converts CMSampleBuffer frames to WebRTC VideoFrames and feeds them
+ * into a VideoBroadcaster so WebRTC sinks receive them.
+ */
+
+#import <AVFoundation/AVFoundation.h>
+#import <Foundation/Foundation.h>
+
+#include "AVFCaptureVideoSource.hpp"
+#include "api/make_ref_counted.h"
+#include "api/video/i420_buffer.h"
+#include "api/video/video_frame.h"
+#include "rtc_base/time_utils.h"
+#include "api/peer_connection_interface.h"
+#include "third_party/libyuv/include/libyuv/convert.h"
+#include <iostream>
+
+// ---------------------------------------------------------------------------
+// ObjC frame delegate
+// ---------------------------------------------------------------------------
+
+@interface AVFCaptureDelegate
+    : NSObject <AVCaptureVideoDataOutputSampleBufferDelegate>
+- (instancetype)initWithBroadcaster:(webrtc::VideoBroadcaster*)broadcaster;
+@end
+
+@implementation AVFCaptureDelegate {
+	webrtc::VideoBroadcaster* _broadcaster;
+}
+
+- (instancetype)initWithBroadcaster:(webrtc::VideoBroadcaster*)broadcaster
+{
+	self          = [super init];
+	_broadcaster  = broadcaster;
+	return self;
+}
+
+- (void)captureOutput:(AVCaptureOutput*)output
+  didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
+         fromConnection:(AVCaptureConnection*)connection
+{
+	CVPixelBufferRef pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
+	if (!pixelBuffer)
+		return;
+
+	CVPixelBufferLockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
+
+	const int width  = (int)CVPixelBufferGetWidth(pixelBuffer);
+	const int height = (int)CVPixelBufferGetHeight(pixelBuffer);
+	OSType fmt       = CVPixelBufferGetPixelFormatType(pixelBuffer);
+
+	auto i420 = webrtc::I420Buffer::Create(width, height);
+
+	if (fmt == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange ||
+	    fmt == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange)
+	{
+		// NV12
+		const uint8_t* y  = (uint8_t*)CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 0);
+		const uint8_t* uv = (uint8_t*)CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 1);
+		libyuv::NV12ToI420(
+		  y, (int)CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, 0),
+		  uv, (int)CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, 1),
+		  i420->MutableDataY(), i420->StrideY(),
+		  i420->MutableDataU(), i420->StrideU(),
+		  i420->MutableDataV(), i420->StrideV(),
+		  width, height);
+	}
+	else if (fmt == kCVPixelFormatType_32BGRA)
+	{
+		const uint8_t* bgra = (uint8_t*)CVPixelBufferGetBaseAddress(pixelBuffer);
+		libyuv::ARGBToI420(
+		  bgra, (int)CVPixelBufferGetBytesPerRow(pixelBuffer),
+		  i420->MutableDataY(), i420->StrideY(),
+		  i420->MutableDataU(), i420->StrideU(),
+		  i420->MutableDataV(), i420->StrideV(),
+		  width, height);
+	}
+	else
+	{
+		CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
+		return; // unsupported format
+	}
+
+	CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
+
+	webrtc::VideoFrame frame =
+	  webrtc::VideoFrame::Builder()
+	    .set_video_frame_buffer(i420)
+	    .set_timestamp_us(webrtc::TimeMicros())
+	    .build();
+
+	_broadcaster->OnFrame(frame);
+}
+@end
+
+// ---------------------------------------------------------------------------
+// ObjC capture session wrapper
+// ---------------------------------------------------------------------------
+
+@interface AVFCaptureImpl : NSObject
+- (instancetype)initWithBroadcaster:(webrtc::VideoBroadcaster*)broadcaster
+                              width:(int)width
+                             height:(int)height
+                                fps:(int)fps;
+- (BOOL)start;
+- (void)stop;
+@end
+
+@implementation AVFCaptureImpl {
+	AVCaptureSession* _session;
+	AVFCaptureDelegate* _delegate;
+	dispatch_queue_t _queue;
+}
+
+- (instancetype)initWithBroadcaster:(webrtc::VideoBroadcaster*)broadcaster
+                              width:(int)width
+                             height:(int)height
+                                fps:(int)fps
+{
+	self = [super init];
+	if (!self)
+		return nil;
+
+	_queue    = dispatch_queue_create("avf_capture", DISPATCH_QUEUE_SERIAL);
+	_delegate = [[AVFCaptureDelegate alloc] initWithBroadcaster:broadcaster];
+	_session  = [[AVCaptureSession alloc] init];
+
+	// Camera device
+	AVCaptureDevice* device =
+	  [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
+	if (!device)
+	{
+		std::cerr << "[video] no camera device found\n";
+		return nil;
+	}
+	std::cout << "[video] camera: " << [device.localizedName UTF8String] << "\n";
+
+	NSError* error = nil;
+	AVCaptureDeviceInput* input =
+	  [AVCaptureDeviceInput deviceInputWithDevice:device error:&error];
+	if (error || !input)
+	{
+		std::cerr << "[video] failed to create camera input\n";
+		return nil;
+	}
+
+	// Output
+	AVCaptureVideoDataOutput* output = [[AVCaptureVideoDataOutput alloc] init];
+	output.videoSettings = @{
+		(NSString*)kCVPixelBufferPixelFormatTypeKey :
+		  @(kCVPixelFormatType_420YpCbCr8BiPlanarFullRange)
+	};
+	output.alwaysDiscardsLateVideoFrames = YES;
+	[output setSampleBufferDelegate:_delegate queue:_queue];
+
+	[_session beginConfiguration];
+	if ([_session canAddInput:input])
+		[_session addInput:input];
+	if ([_session canAddOutput:output])
+		[_session addOutput:output];
+
+	// Frame rate
+	AVCaptureConnection* conn =
+	  [output connectionWithMediaType:AVMediaTypeVideo];
+	if (conn && conn.isVideoMinFrameDurationSupported)
+		conn.videoMinFrameDuration = CMTimeMake(1, fps);
+
+	[_session commitConfiguration];
+	return self;
+}
+
+- (BOOL)start
+{
+	[_session startRunning];
+	return _session.isRunning;
+}
+
+- (void)stop
+{
+	[_session stopRunning];
+}
+@end
+
+// ---------------------------------------------------------------------------
+// C++ AVFCaptureVideoSource
+// ---------------------------------------------------------------------------
+
+AVFCaptureVideoSource::AVFCaptureVideoSource()
+  : webrtc::VideoTrackSource(/*remote=*/false), impl(nullptr)
+{
+}
+
+AVFCaptureVideoSource::~AVFCaptureVideoSource()
+{
+	if (this->impl)
+	{
+		[(__bridge AVFCaptureImpl*)this->impl stop];
+		CFRelease(this->impl);
+	}
+}
+
+// static
+webrtc::scoped_refptr<AVFCaptureVideoSource> AVFCaptureVideoSource::Create(
+  int width, int height, int fps)
+{
+	// Request camera permission
+	__block BOOL granted = NO;
+	dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+	[AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo
+	                         completionHandler:^(BOOL g) {
+		                         granted = g;
+		                         dispatch_semaphore_signal(sem);
+	                         }];
+	dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
+
+	if (!granted)
+	{
+		std::cerr << "[video] camera permission denied\n";
+		return nullptr;
+	}
+
+	auto source = webrtc::make_ref_counted<AVFCaptureVideoSource>();
+
+	AVFCaptureImpl* impl =
+	  [[AVFCaptureImpl alloc] initWithBroadcaster:&source->broadcaster
+	                                        width:width
+	                                       height:height
+	                                          fps:fps];
+	if (!impl)
+		return nullptr;
+
+	source->impl = (void*)CFBridgingRetain(impl);
+
+	if (![impl start])
+	{
+		std::cerr << "[video] failed to start camera\n";
+		return nullptr;
+	}
+
+	std::cout << "[video] camera started " << width << "x" << height << "@" << fps << "fps\n";
+	return source;
+}
+
+webrtc::VideoSourceInterface<webrtc::VideoFrame>* AVFCaptureVideoSource::source()
+{
+	return &broadcaster;
+}
+
+void AVFCaptureVideoSource::AddOrUpdateSink(
+  webrtc::VideoSinkInterface<webrtc::VideoFrame>* sink,
+  const webrtc::VideoSinkWants& wants)
+{
+	broadcaster.AddOrUpdateSink(sink, wants);
+}
+
+void AVFCaptureVideoSource::RemoveSink(
+  webrtc::VideoSinkInterface<webrtc::VideoFrame>* sink)
+{
+	broadcaster.RemoveSink(sink);
+}

--- a/demo/src/CaptureVideoSource.hpp
+++ b/demo/src/CaptureVideoSource.hpp
@@ -1,0 +1,102 @@
+#pragma once
+
+#include "api/video/video_frame.h"
+#include "api/video/video_sink_interface.h"
+#include "media/base/video_broadcaster.h"
+#include "modules/video_capture/video_capture.h"
+#include "modules/video_capture/video_capture_factory.h"
+#include "pc/video_track_source.h"
+#include <iostream>
+#include <memory>
+
+/**
+ * VideoTrackSource backed by a real camera via WebRTC's VideoCaptureModule.
+ * Implements VideoSinkInterface so it can be registered directly as the
+ * capture callback, and forwards frames to a VideoBroadcaster that
+ * distributes them to WebRTC sinks.
+ */
+class CaptureVideoSource : public webrtc::VideoTrackSource,
+                           public webrtc::VideoSinkInterface<webrtc::VideoFrame>
+{
+public:
+	static webrtc::scoped_refptr<CaptureVideoSource> Create(int width, int height, int fps)
+	{
+		auto deviceInfo = std::unique_ptr<webrtc::VideoCaptureModule::DeviceInfo>(
+		  webrtc::VideoCaptureFactory::CreateDeviceInfo());
+
+		if (!deviceInfo || deviceInfo->NumberOfDevices() == 0)
+		{
+			std::cerr << "[video] no camera devices found\n";
+			return nullptr;
+		}
+
+		char name[256];
+		char uniqueId[256];
+		deviceInfo->GetDeviceName(0, name, sizeof(name), uniqueId, sizeof(uniqueId));
+		std::cout << "[video] using camera: " << name << "\n";
+
+		auto capturer = webrtc::VideoCaptureFactory::Create(uniqueId);
+		if (!capturer)
+		{
+			std::cerr << "[video] failed to create capturer\n";
+			return nullptr;
+		}
+
+		webrtc::VideoCaptureCapability capability;
+		capability.width     = width;
+		capability.height    = height;
+		capability.maxFPS    = fps;
+		capability.videoType = webrtc::VideoType::kI420;
+
+		auto source = webrtc::make_ref_counted<CaptureVideoSource>(capturer);
+
+		if (capturer->StartCapture(capability) != 0)
+		{
+			std::cerr << "[video] failed to start capture\n";
+			return nullptr;
+		}
+
+		std::cout << "[video] camera started " << width << "x" << height << "@" << fps << "fps\n";
+		return source;
+	}
+
+	explicit CaptureVideoSource(webrtc::scoped_refptr<webrtc::VideoCaptureModule> capturer)
+	  : webrtc::VideoTrackSource(/*remote=*/false), capturer_(capturer)
+	{
+		capturer_->RegisterCaptureDataCallback(this);
+	}
+
+	~CaptureVideoSource() override
+	{
+		capturer_->StopCapture();
+		capturer_->DeRegisterCaptureDataCallback();
+	}
+
+	// VideoSinkInterface — called by the capture module with each new frame
+	void OnFrame(const webrtc::VideoFrame& frame) override
+	{
+		broadcaster_.OnFrame(frame);
+	}
+
+	// VideoTrackSource
+	webrtc::VideoSourceInterface<webrtc::VideoFrame>* source() override
+	{
+		return &broadcaster_;
+	}
+
+protected:
+	void AddOrUpdateSink(
+	  webrtc::VideoSinkInterface<webrtc::VideoFrame>* sink, const webrtc::VideoSinkWants& wants) override
+	{
+		broadcaster_.AddOrUpdateSink(sink, wants);
+	}
+
+	void RemoveSink(webrtc::VideoSinkInterface<webrtc::VideoFrame>* sink) override
+	{
+		broadcaster_.RemoveSink(sink);
+	}
+
+private:
+	webrtc::scoped_refptr<webrtc::VideoCaptureModule> capturer_;
+	webrtc::VideoBroadcaster broadcaster_;
+};

--- a/demo/src/ProtooClient.cpp
+++ b/demo/src/ProtooClient.cpp
@@ -1,0 +1,205 @@
+#include "ProtooClient.hpp"
+
+#include <iostream>
+#include <stdexcept>
+#include <thread>
+
+ProtooClient::ProtooClient(
+  const std::string& url,
+  const std::string& origin,
+  NotificationCallback notificationCb,
+  RequestCallback requestCb)
+  : notificationCb(std::move(notificationCb)), requestCb(std::move(requestCb))
+{
+	this->ws.setUrl(url);
+
+	// Protoo requires this subprotocol header.
+	this->ws.addSubProtocol("protoo");
+
+	// The mediasoup-demo server validates the Origin header against its domain.
+	// clang-format off
+	this->ws.setExtraHeaders(
+	  {
+	    { "Origin", origin },
+	  });
+	// clang-format on
+
+	// Disable TLS cert verification for local self-signed certs.
+	ix::SocketTLSOptions tlsOpts;
+	tlsOpts.disable_hostname_validation = true;
+	tlsOpts.caFile                      = "NONE"; // skip CA verification
+	this->ws.setTLSOptions(tlsOpts);
+
+	this->ws.setOnMessageCallback(
+	  [this](const ix::WebSocketMessagePtr& msg)
+	  {
+		  if (msg->type == ix::WebSocketMessageType::Message)
+		  {
+			  this->OnMessage(msg->str);
+		  }
+		  else if (msg->type == ix::WebSocketMessageType::Open)
+		  {
+			  std::lock_guard<std::mutex> lock(this->connMutex);
+			  this->connected = true;
+			  this->connCv.notify_all();
+		  }
+		  else if (msg->type == ix::WebSocketMessageType::Error)
+		  {
+			  std::lock_guard<std::mutex> lock(this->connMutex);
+			  this->connectError = msg->errorInfo.reason;
+			  this->connected    = true; // unblock waitForConnection
+			  this->connCv.notify_all();
+		  }
+	  });
+}
+
+void ProtooClient::Connect(int timeoutMs)
+{
+	this->ws.start();
+
+	std::unique_lock<std::mutex> lock(this->connMutex);
+	this->connCv.wait_for(
+	  lock,
+	  std::chrono::milliseconds(timeoutMs),
+	  [this]
+	  {
+		  return this->connected;
+	  });
+
+	if (!this->connectError.empty())
+	{
+		throw std::runtime_error("WebSocket connection failed: " + this->connectError);
+	}
+
+	if (!this->connected)
+	{
+		throw std::runtime_error("WebSocket connection timed out");
+	}
+}
+
+void ProtooClient::Close()
+{
+	this->ws.stop();
+}
+
+json ProtooClient::Request(const std::string& method, const json& data)
+{
+	const int id = this->nextId++;
+
+	// clang-format off
+	json msg = {
+		{ "request", true   },
+		{ "id",      id     },
+		{ "method",  method },
+		{ "data",    data   },
+	};
+	// clang-format on
+
+	std::promise<json> promise;
+	auto future = promise.get_future();
+
+	{
+		std::lock_guard<std::mutex> lock(this->pendingMutex);
+		this->pending[id] = std::move(promise);
+	}
+
+	this->ws.sendText(msg.dump());
+
+	auto status = future.wait_for(std::chrono::seconds(10));
+
+	if (status != std::future_status::ready)
+	{
+		throw std::runtime_error("Protoo request timed out: " + method);
+	}
+
+	return future.get(); // throws if response was an error
+}
+
+void ProtooClient::OnMessage(const std::string& str)
+{
+	json msg;
+
+	try
+	{
+		msg = json::parse(str);
+	}
+	catch (const std::exception& e)
+	{
+		std::cerr << "[protoo] failed to parse message: " << e.what() << "\n";
+
+		return;
+	}
+
+	if (msg.value("response", false))
+	{
+		const int id = msg["id"];
+		std::lock_guard<std::mutex> lock(this->pendingMutex);
+		auto it = this->pending.find(id);
+
+		if (it == this->pending.end())
+		{
+			return;
+		}
+
+		if (msg.value("ok", false))
+		{
+			it->second.set_value(msg.value("data", json::object()));
+		}
+		else
+		{
+			it->second.set_exception(
+			  std::make_exception_ptr(std::runtime_error(msg.value("errorReason", "unknown error"))));
+		}
+
+		this->pending.erase(it);
+	}
+	else if (msg.value("notification", false))
+	{
+		this->notificationCb(msg["method"], msg.value("data", json::object()));
+	}
+	else if (msg.value("request", false))
+	{
+		// Server-initiated request.
+		// IMPORTANT: dispatch to a worker thread so we don't block the ixwebsocket
+		// receive thread. Blocking it (e.g. via a nested protoo.request() inside
+		// ConsumeData → OnConnect) would deadlock because the thread can't receive
+		// the response for the nested request while it's blocked.
+		const int id             = msg["id"];
+		const std::string method = msg["method"];
+		const json data          = msg.value("data", json::object());
+
+		std::thread(
+		  [this, id, method, data]()
+		  {
+			  json responseData = json::object();
+			  try
+			  {
+				  this->requestCb(method, data, responseData);
+
+				  // clang-format off
+				  json response = {
+					  { "response", true         },
+					  { "id",       id           },
+					  { "ok",       true         },
+					  { "data",     responseData },
+				  };
+				  // clang-format on
+				  this->ws.sendText(response.dump());
+			  }
+			  catch (const std::exception& e)
+			  {
+				  std::cerr << "[protoo] request '" << method << "' handler error: " << e.what() << "\n";
+				  // clang-format off
+				  json response = {
+					  { "response",    true     },
+					  { "id",          id       },
+					  { "ok",          false    },
+					  { "errorReason", e.what() },
+				  };
+				  // clang-format on
+				  this->ws.sendText(response.dump());
+			  }
+		  })
+		  .detach();
+	}
+}

--- a/demo/src/RoomClient.cpp
+++ b/demo/src/RoomClient.cpp
@@ -3,7 +3,7 @@
 #include <stdexcept>
 
 // ---------------------------------------------------------------------------
-// Private listener classes — full definitions
+// Private listener classes
 // ---------------------------------------------------------------------------
 
 class RoomClient::SendTransportListener : public mediasoupclient::SendTransport::Listener
@@ -17,6 +17,7 @@ public:
 	std::future<void> OnConnect(mediasoupclient::Transport* /*transport*/, const json& dtlsParameters) override
 	{
 		std::promise<void> p;
+
 		try
 		{
 			this->protoo.Request(

--- a/demo/src/RoomClient.cpp
+++ b/demo/src/RoomClient.cpp
@@ -1,0 +1,555 @@
+#include "RoomClient.hpp"
+#include <iostream>
+#include <stdexcept>
+
+// ---------------------------------------------------------------------------
+// Private listener classes — full definitions
+// ---------------------------------------------------------------------------
+
+class RoomClient::SendTransportListener : public mediasoupclient::SendTransport::Listener
+{
+public:
+	SendTransportListener(ProtooClient& protoo, const std::string& transportId)
+	  : protoo(protoo), transportId(transportId)
+	{
+	}
+
+	std::future<void> OnConnect(mediasoupclient::Transport* /*transport*/, const json& dtlsParameters) override
+	{
+		std::promise<void> p;
+		try
+		{
+			this->protoo.Request(
+			  "connectWebRtcTransport",
+			  // clang-format off
+			  {
+				{ "transportId",    this->transportId },
+				{ "dtlsParameters", dtlsParameters    },
+			  });
+			// clang-format on
+
+			p.set_value();
+		}
+		catch (const std::exception& e)
+		{
+			std::cerr << "[send] OnConnect failed: " << e.what() << "\n";
+
+			p.set_exception(std::current_exception());
+		}
+
+		return p.get_future();
+	}
+
+	void OnConnectionStateChange(mediasoupclient::Transport*, const std::string& state) override
+	{
+		std::cout << "[send] connection state changed to: " << state << "\n";
+	}
+
+	std::future<std::string> OnProduce(
+	  mediasoupclient::SendTransport* /*transport*/,
+	  const std::string& kind,
+	  json rtpParameters,
+	  const json& appData) override
+	{
+		std::promise<std::string> p;
+
+		try
+		{
+			auto res = this->protoo.Request(
+			  "produce",
+			  // clang-format off
+			  {
+				{ "transportId",   this->transportId },
+				{ "kind",          kind              },
+				{ "rtpParameters", rtpParameters     },
+				{ "appData",       appData           },
+			  });
+			// clang-format on
+
+			p.set_value(res["producerId"].get<std::string>());
+		}
+		catch (const std::exception& e)
+		{
+			std::cerr << "[send] OnProduce failed: " << e.what() << "\n";
+
+			p.set_exception(std::current_exception());
+		}
+
+		return p.get_future();
+	}
+
+	std::future<std::string> OnProduceData(
+	  mediasoupclient::SendTransport* /*transport*/,
+	  const json& sctpStreamParameters,
+	  const std::string& label,
+	  const std::string& protocol,
+	  const json& appData) override
+	{
+		std::promise<std::string> p;
+
+		try
+		{
+			auto res = this->protoo.Request(
+			  "produceData",
+			  // clang-format off
+			  {
+				{ "transportId",          this->transportId    },
+				{ "sctpStreamParameters", sctpStreamParameters },
+				{ "label",                label                },
+				{ "protocol",             protocol             },
+				{ "appData",              appData              },
+			  });
+			// clang-format on
+
+			p.set_value(res["dataProducerId"].get<std::string>());
+		}
+		catch (const std::exception& e)
+		{
+			std::cerr << "[send] OnProduceData failed: " << e.what() << "\n";
+
+			p.set_exception(std::current_exception());
+		}
+
+		return p.get_future();
+	}
+
+private:
+	ProtooClient& protoo;
+	std::string transportId;
+};
+
+class RoomClient::RecvTransportListener : public mediasoupclient::RecvTransport::Listener
+{
+public:
+	RecvTransportListener(ProtooClient& protoo, const std::string& transportId)
+	  : protoo(protoo), transportId(transportId)
+	{
+	}
+
+	std::future<void> OnConnect(mediasoupclient::Transport* /*transport*/, const json& dtlsParameters) override
+	{
+		std::promise<void> p;
+
+		try
+		{
+			this->protoo.Request(
+			  "connectWebRtcTransport",
+			  // clang-format off
+			  {
+				{ "transportId",    this->transportId },
+				{ "dtlsParameters", dtlsParameters    },
+			  });
+			// clang-format on
+
+			p.set_value();
+		}
+		catch (const std::exception& e)
+		{
+			std::cerr << "[recv] OnConnect failed: " << e.what() << "\n";
+			p.set_exception(std::current_exception());
+		}
+
+		return p.get_future();
+	}
+
+	void OnConnectionStateChange(mediasoupclient::Transport* /*transport*/, const std::string& state) override
+	{
+		std::cout << "[recv] connection state changed to: " << state << "\n";
+	}
+
+private:
+	ProtooClient& protoo;
+	std::string transportId;
+};
+
+class RoomClient::ProducerListener : public mediasoupclient::Producer::Listener
+{
+public:
+	void OnTransportClose(mediasoupclient::Producer* /*producer*/) override
+	{
+	}
+};
+
+class RoomClient::ConsumerListener : public mediasoupclient::Consumer::Listener
+{
+public:
+	void OnTransportClose(mediasoupclient::Consumer* /*consumer*/) override
+	{
+	}
+};
+
+class RoomClient::DataProducerListener : public mediasoupclient::DataProducer::Listener
+{
+public:
+	void OnOpen(mediasoupclient::DataProducer* /*dataProducer*/) override
+	{
+	}
+	void OnClose(mediasoupclient::DataProducer* /*dataProducer*/) override
+	{
+	}
+	void OnBufferedAmountChange(
+	  mediasoupclient::DataProducer* /*dataProducer*/, uint64_t /*sentDataSize*/) override
+	{
+	}
+	void OnTransportClose(mediasoupclient::DataProducer* /*dataProducer*/) override
+	{
+	}
+};
+
+class RoomClient::DataConsumerListener : public mediasoupclient::DataConsumer::Listener
+{
+public:
+	explicit DataConsumerListener(RoomClient& room) : room(room)
+	{
+	}
+
+	void OnConnecting(mediasoupclient::DataConsumer* /*dataConsumer*/) override
+	{
+	}
+	void OnOpen(mediasoupclient::DataConsumer* /*dataConsumer*/) override
+	{
+	}
+	void OnClosing(mediasoupclient::DataConsumer* /*dataConsumer*/) override
+	{
+	}
+	void OnClose(mediasoupclient::DataConsumer* /*dataConsumer*/) override
+	{
+	}
+	void OnMessage(mediasoupclient::DataConsumer* /*dataConsumer*/, const webrtc::DataBuffer& buffer) override
+	{
+		this->room.onDataMessage(std::string(buffer.data.data<char>(), buffer.data.size()));
+	}
+	void OnTransportClose(mediasoupclient::DataConsumer* /*dataConsumer*/) override
+	{
+	}
+
+private:
+	RoomClient& room;
+};
+
+// ---------------------------------------------------------------------------
+// RoomClient
+// ---------------------------------------------------------------------------
+
+RoomClient::RoomClient(
+  const std::string& url,
+  const std::string& origin,
+  const std::string& displayName,
+  webrtc::PeerConnectionFactoryInterface* factory,
+  mediasoupclient::PeerConnection::Options pcOptions,
+  std::function<void(const std::string& peerId, webrtc::VideoTrackInterface*)> onNewVideoTrack,
+  std::function<void(const std::string& peerId)> onPeerLeft,
+  std::function<void(const std::string& message)> onDataMessage)
+  : protoo(
+      url,
+      origin,
+      [this](const std::string& method, const json& data)
+      {
+	      this->HandleNotification(method, data);
+      },
+      [this](const std::string& method, const json& data, json& responseData)
+      {
+	      this->HandleRequest(method, data, responseData);
+      }),
+    displayName(displayName),
+    factory(factory),
+    pcOptions(std::move(pcOptions)),
+    onNewVideoTrack(std::move(onNewVideoTrack)),
+    onPeerLeft(std::move(onPeerLeft)),
+    onDataMessage(std::move(onDataMessage))
+{
+	this->pcOptions.factory = this->factory;
+}
+
+RoomClient::~RoomClient()
+{
+	this->Close();
+}
+
+void RoomClient::Join()
+{
+	this->protoo.Connect();
+	std::cout << "[room] connected\n";
+
+	// -- Load device --
+	auto res = this->protoo.Request("getRouterRtpCapabilities");
+
+	this->device.Load(res["routerRtpCapabilities"], &this->pcOptions);
+	std::cout << "[room] device loaded\n";
+
+	// -- SendTransport --
+	{
+		auto r = this->protoo.Request(
+		  "createWebRtcTransport",
+		  // clang-format off
+		  {
+			{ "forceTcp",         false                                },
+			{ "sctpCapabilities", this->device.GetSctpCapabilities()  },
+			{ "appData",          { { "direction", "producer" } }     },
+		  });
+		// clang-format on
+
+		this->sendListener  = std::make_unique<SendTransportListener>(this->protoo, r["transportId"]);
+		this->sendTransport = this->device.CreateSendTransport(
+		  this->sendListener.get(),
+		  r["transportId"],
+		  r["iceParameters"],
+		  r["iceCandidates"],
+		  r["dtlsParameters"],
+		  r["sctpParameters"],
+		  &this->pcOptions);
+	}
+
+	// -- RecvTransport --
+	{
+		auto r = this->protoo.Request(
+		  "createWebRtcTransport",
+		  // clang-format off
+		  {
+			{ "forceTcp",         false                                },
+			{ "sctpCapabilities", this->device.GetSctpCapabilities()  },
+			{ "appData",          { { "direction", "consumer" } }     },
+		  });
+		// clang-format on
+
+		this->recvListener  = std::make_unique<RecvTransportListener>(this->protoo, r["transportId"]);
+		this->recvTransport = this->device.CreateRecvTransport(
+		  this->recvListener.get(),
+		  r["transportId"],
+		  r["iceParameters"],
+		  r["iceCandidates"],
+		  r["dtlsParameters"],
+		  r["sctpParameters"],
+		  &this->pcOptions);
+	}
+
+	// -- Wire up server requests and notifications --
+	this->consumerListener     = std::make_unique<ConsumerListener>();
+	this->producerListener     = std::make_unique<ProducerListener>();
+	this->dataProducerListener = std::make_unique<DataProducerListener>();
+	this->dataConsumerListener = std::make_unique<DataConsumerListener>(*this);
+
+	// -- Join room --
+	this->protoo.Request(
+	  "join",
+	  // clang-format off
+	  {
+		{ "displayName",      this->displayName                   },
+		{ "device",           { { "name", "mediasoupclient" } }   },
+		{ "rtpCapabilities",  this->device.GetRtpCapabilities()   },
+		{ "sctpCapabilities", this->device.GetSctpCapabilities()  },
+	  });
+	// clang-format on
+
+	std::cout << "[room] joined\n";
+}
+
+void RoomClient::Close()
+{
+	if (this->closed)
+	{
+		return;
+	}
+
+	this->closed = true;
+
+	std::cout << "[room] closing...\n";
+
+	// Close transports first — each Close() calls TransportClosed() on all its
+	// producers/consumers before tearing down the PeerConnection. Only after
+	// the transport is done do we delete the raw pointers we hold.
+	if (this->sendTransport)
+	{
+		this->sendTransport->Close();
+		delete this->sendTransport;
+		this->sendTransport = nullptr;
+	}
+
+	delete this->micProducer;
+	this->micProducer = nullptr;
+
+	delete this->cameraProducer;
+	this->cameraProducer = nullptr;
+
+	delete this->chatDataProducer;
+	this->chatDataProducer = nullptr;
+
+	if (this->recvTransport)
+	{
+		this->recvTransport->Close();
+		delete this->recvTransport;
+		this->recvTransport = nullptr;
+	}
+
+	// Delete consumer pointers after the transport has already notified them.
+	{
+		std::lock_guard<std::mutex> lock(this->participantsMutex);
+
+		for (auto& kv : this->participants)
+		{
+			delete kv.second.audioConsumer;
+			delete kv.second.videoConsumer;
+		}
+
+		this->participants.clear();
+	}
+
+	for (auto* dc : this->dataConsumers)
+	{
+		delete dc;
+	}
+
+	this->dataConsumers.clear();
+
+	this->protoo.Close();
+}
+
+void RoomClient::EnableMic()
+{
+	auto audioSource = this->factory->CreateAudioSource({});
+	auto audioTrack  = this->factory->CreateAudioTrack("mic", audioSource.get());
+
+	this->micProducer = this->sendTransport->Produce(
+	  this->producerListener.get(), audioTrack.get(), nullptr, nullptr, {});
+
+	std::cout << "[room] mic producer: " << this->micProducer->GetId() << "\n";
+}
+
+void RoomClient::DisableMic()
+{
+	if (!this->micProducer)
+	{
+		return;
+	}
+
+	this->micProducer->Close();
+	delete this->micProducer;
+	this->micProducer = nullptr;
+}
+
+void RoomClient::EnableCamera(webrtc::scoped_refptr<webrtc::VideoTrackInterface> videoTrack)
+{
+	if (!videoTrack)
+	{
+		return;
+	}
+
+	this->cameraProducer = this->sendTransport->Produce(
+	  this->producerListener.get(), videoTrack.get(), nullptr, nullptr, {});
+
+	std::cout << "[room] camera producer: " << this->cameraProducer->GetId() << "\n";
+}
+
+void RoomClient::DisableCamera()
+{
+	if (!this->cameraProducer)
+	{
+		return;
+	}
+
+	this->cameraProducer->Close();
+	delete this->cameraProducer;
+	this->cameraProducer = nullptr;
+}
+
+void RoomClient::EnableChat()
+{
+	this->chatDataProducer = this->sendTransport->ProduceData(
+	  this->dataProducerListener.get(),
+	  "chat",
+	  "text/plain",
+	  true,
+	  0,
+	  0,
+	  // clang-format off
+	  {
+		{ "channel", "chat" },
+	  });
+	// clang-format on
+
+	std::cout << "[room] chat data producer: " << this->chatDataProducer->GetId() << "\n";
+}
+
+// ---------------------------------------------------------------------------
+// Private handlers
+// ---------------------------------------------------------------------------
+
+void RoomClient::HandleRequest(const std::string& method, const json& data, json& /*responseData*/)
+{
+	std::lock_guard<std::mutex> lock(this->handleRequestMutex);
+
+	if (method == "newConsumer")
+	{
+		const auto consumerId = data["consumerId"].get<std::string>();
+		const auto producerId = data["producerId"].get<std::string>();
+		const auto kind       = data["kind"].get<std::string>();
+		const auto peerIdFrom = data["peerId"].get<std::string>();
+		auto rtpParameters    = data["rtpParameters"];
+
+		auto* consumer = this->recvTransport->Consume(
+		  this->consumerListener.get(), consumerId, producerId, kind, &rtpParameters);
+
+		{
+			std::lock_guard<std::mutex> lock(this->participantsMutex);
+			auto& p = this->participants[peerIdFrom];
+
+			if (kind == "audio")
+			{
+				p.audioConsumer = consumer;
+			}
+			else if (kind == "video")
+			{
+				p.videoConsumer = consumer;
+			}
+		}
+
+		std::cout << "[room] consuming " << kind << " from " << peerIdFrom << "\n";
+
+		if (kind == "video")
+		{
+			auto* track = static_cast<webrtc::VideoTrackInterface*>(consumer->GetTrack());
+
+			this->onNewVideoTrack(peerIdFrom, track);
+		}
+	}
+	else if (method == "newDataConsumer")
+	{
+		auto* dc = this->recvTransport->ConsumeData(
+		  this->dataConsumerListener.get(),
+		  data["dataConsumerId"].get<std::string>(),
+		  data["dataProducerId"].get<std::string>(),
+		  static_cast<uint16_t>(data["sctpStreamParameters"]["streamId"].get<int>()),
+		  data.value("label", ""),
+		  data.value("protocol", ""),
+		  data.value("appData", json::object()));
+
+		this->dataConsumers.push_back(dc);
+	}
+}
+
+void RoomClient::HandleNotification(const std::string& method, const json& data)
+{
+	if (method == "newPeer")
+	{
+		std::cout << "[room] new peer: " << data["id"].get<std::string>() << "\n";
+	}
+	else if (method == "peerClosed")
+	{
+		const auto peerId = data["peerId"].get<std::string>();
+		{
+			std::lock_guard<std::mutex> lock(this->participantsMutex);
+			auto it = this->participants.find(peerId);
+
+			if (it != this->participants.end())
+			{
+				delete it->second.audioConsumer;
+				delete it->second.videoConsumer;
+				this->participants.erase(it);
+			}
+		}
+
+		std::cout << "[room] peer left: " << peerId << "\n";
+
+		this->onPeerLeft(peerId);
+	}
+}

--- a/demo/src/main.cpp
+++ b/demo/src/main.cpp
@@ -1,0 +1,204 @@
+/**
+ * mediasoupclient demo
+ *
+ * Connects to a mediasoup-demo server, sends mic audio and camera
+ * video, and receives audio/video from other participants.
+ * Runs until Ctrl+C.
+ *
+ * Usage:
+ *   mediasoupclient_demo --ws-url [serverUrl]  --origin [origin]
+ */
+
+#include "AVFCaptureVideoSource.hpp"
+#include "RoomClient.hpp"
+#include "Utils.hpp"
+#include "api/audio_codecs/builtin_audio_decoder_factory.h"
+#include "api/audio_codecs/builtin_audio_encoder_factory.h"
+#include "api/create_peerconnection_factory.h"
+#include "api/video_codecs/video_decoder_factory_template.h"
+#include "api/video_codecs/video_decoder_factory_template_dav1d_adapter.h"
+#include "api/video_codecs/video_decoder_factory_template_libvpx_vp8_adapter.h"
+#include "api/video_codecs/video_decoder_factory_template_libvpx_vp9_adapter.h"
+#include "api/video_codecs/video_decoder_factory_template_open_h264_adapter.h"
+#include "api/video_codecs/video_encoder_factory_template.h"
+#include "api/video_codecs/video_encoder_factory_template_libaom_av1_adapter.h"
+#include "api/video_codecs/video_encoder_factory_template_libvpx_vp8_adapter.h"
+#include "api/video_codecs/video_encoder_factory_template_libvpx_vp9_adapter.h"
+#include "api/video_codecs/video_encoder_factory_template_open_h264_adapter.h"
+#include "rtc_base/thread.h"
+#include <CLI/CLI.hpp>
+#include <atomic>
+#include <csignal>
+#include <iostream>
+#include <thread>
+
+// ---------------------------------------------------------------------------
+// Graceful shutdown on Ctrl+C
+// ---------------------------------------------------------------------------
+
+static std::atomic<bool> Running{ true };
+
+static void onSignal(int /*unused*/)
+{
+	Running = false;
+}
+
+// ---------------------------------------------------------------------------
+// PeerConnectionFactory
+// ---------------------------------------------------------------------------
+
+static webrtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> createFactory()
+{
+	auto* network   = webrtc::Thread::CreateWithSocketServer().release();
+	auto* worker    = webrtc::Thread::Create().release();
+	auto* signaling = webrtc::Thread::Create().release();
+
+	network->SetName("demo_network", nullptr);
+	worker->SetName("demo_worker", nullptr);
+	signaling->SetName("demo_signaling", nullptr);
+
+	network->Start();
+	worker->Start();
+	signaling->Start();
+
+	return webrtc::CreatePeerConnectionFactory(
+	  network,
+	  worker,
+	  signaling,
+	  nullptr,
+	  webrtc::CreateBuiltinAudioEncoderFactory(),
+	  webrtc::CreateBuiltinAudioDecoderFactory(),
+	  std::make_unique<webrtc::VideoEncoderFactoryTemplate<
+	    webrtc::LibvpxVp8EncoderTemplateAdapter,
+	    webrtc::LibvpxVp9EncoderTemplateAdapter,
+	    webrtc::OpenH264EncoderTemplateAdapter,
+	    webrtc::LibaomAv1EncoderTemplateAdapter>>(),
+	  std::make_unique<webrtc::VideoDecoderFactoryTemplate<
+	    webrtc::LibvpxVp8DecoderTemplateAdapter,
+	    webrtc::LibvpxVp9DecoderTemplateAdapter,
+	    webrtc::OpenH264DecoderTemplateAdapter,
+	    webrtc::Dav1dDecoderTemplateAdapter>>(),
+	  nullptr,
+	  nullptr,
+	  nullptr,
+	  nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+int main(int argc, char* argv[])
+{
+	CLI::App app{ "mediasoupclient demo — send/receive media via a mediasoup-demo server" };
+
+	std::string wsUrl;
+	std::string origin;
+	std::string roomId = "demo-room";
+
+	app.add_option("--ws-url", wsUrl, "Protoo WebSocket URL (e.g. wss://myserver:4443)")->required();
+	app.add_option("--origin", origin, "HTTP Origin header  (e.g. https://myserver.org:4443)")->required();
+	app.add_option("--room-id", roomId, "Room ID")->capture_default_str();
+
+	CLI11_PARSE(app, argc, argv);
+
+	std::signal(SIGINT, onSignal);
+	std::signal(SIGTERM, onSignal);
+
+	const std::string peerId = mediasoupclient::Utils::GetRandomString(8);
+	const std::string url    = wsUrl + "/?roomId=" + roomId + "&peerId=" + peerId;
+
+	mediasoupclient::Initialize();
+
+	auto factory = createFactory();
+
+	if (!factory)
+	{
+		std::cerr << "[demo] FAILED: could not create PeerConnectionFactory\n";
+
+		return 1;
+	}
+
+	// -- Room --
+	RoomClient room(
+	  url,
+	  origin,
+	  "mediasoupclient-demo",
+	  factory.get(),
+	  {},
+	  [](const std::string& peerId, webrtc::VideoTrackInterface*)
+	  {
+		  std::cout << "[demo] video track from " << peerId << "\n";
+	  },
+	  [](const std::string& peerId)
+	  {
+		  std::cout << "[demo] peer left: " << peerId << "\n";
+	  },
+	  [](const std::string& msg)
+	  {
+		  std::cout << "[data] " << msg << "\n";
+	  });
+
+	try
+	{
+		room.Join();
+	}
+	catch (const std::exception& e)
+	{
+		std::cerr << "[demo] FAILED: join: " << e.what() << "\n";
+
+		return 1;
+	}
+
+	// -- Mic --
+	try
+	{
+		room.EnableMic();
+	}
+	catch (const std::exception& e)
+	{
+		std::cerr << "[demo] FAILED: enableMic: " << e.what() << "\n";
+	}
+
+	// -- Camera --
+	auto videoSource = AVFCaptureVideoSource::Create(640, 480, 30);
+
+	if (videoSource)
+	{
+		auto videoTrack = factory->CreateVideoTrack(videoSource, "camera");
+
+		try
+		{
+			room.EnableCamera(videoTrack);
+		}
+		catch (const std::exception& e)
+		{
+			std::cerr << "[demo] FAILED: enableCamera: " << e.what() << "\n";
+		}
+	}
+
+	// -- Chat --
+	try
+	{
+		room.EnableChat();
+	}
+	catch (const std::exception& e)
+	{
+		std::cerr << "[demo] FAILED: enableChat: " << e.what() << "\n";
+	}
+
+	std::cout << "[demo] running — press Ctrl+C to quit\n";
+
+	while (Running)
+	{
+		std::this_thread::sleep_for(std::chrono::milliseconds(100));
+	}
+
+	std::cout << "\n[demo] shutting down...\n";
+
+	room.Close();
+
+	std::cout << "[demo] done\n";
+
+	return 0;
+}

--- a/include/Consumer.hpp
+++ b/include/Consumer.hpp
@@ -87,7 +87,7 @@ namespace mediasoupclient
 		// Paused flag.
 		bool paused{ false };
 		// App custom data.
-		nlohmann::json appData{};
+		nlohmann::json appData;
 	};
 } // namespace mediasoupclient
 

--- a/scripts/clang-scripts.mjs
+++ b/scripts/clang-scripts.mjs
@@ -12,7 +12,7 @@ const NUM_CORES = getNumCores();
 const CLANG_FORMAT_VERSION = 22;
 const CLANG_TIDY_VERSION = 21;
 
-const CLANG_FORMAT_PATHS = ["src/**/*.cpp", "include/**/*.hpp", "test/**/*.cpp", "test/**/*.hpp"];
+const CLANG_FORMAT_PATHS = ["src/**/*.cpp", "include/**/*.hpp", "test/**/*.cpp", "test/**/*.hpp", "demo/**/*.cpp", "demo/**/*.hpp"];
 
 const CLANG_TIDY_PATHS = ["src/**/*.cpp", "test/**/*.cpp"];
 


### PR DESCRIPTION
Basic CLI demo:

- Connects to a mediasoup-demo server via WS as a browser client does.
- Produces audio and video.
- Consumes remote participants media (no rendering).
- Creates DataProducer|DataConsumer.
  - Prints the received messages via DataChannel.

As an example, this is the output you'll see when running the app:

```
[room] connected
[room] device loaded
[room] joined
[send] connection state changed to: checking
[send] connection state changed to: connected
[send] connection state changed to: completed
[recv] connection state changed to: checking
[room] consuming audio from erztw5ev
[room] mic producer: 4b8af09a-f1ab-4cbe-afc3-d7dbfe36621f
[recv] connection state changed to: connected
[recv] connection state changed to: completed
[video] camera: MacBook Pro Camera
[room] consuming video from erztw5ev
[demo] video track from erztw5ev
[data] Welcome mediasoupclient-demo! ☺️
[video] camera started 640x480@30fps
[room] camera producer: 3fa1a8c6-43a5-4431-b3f1-d10653bfb783
[room] chat data producer: b8003f93-544a-4d3a-806e-e280de63e52d
[demo] running — press Ctrl+C to quit
```

Sets the foundations for a more elaborated app.

NOTE 1: This is merely a testing app so we can test the library against our demo.
NOTE 2: The demo is inside the libmediasoupclient repo on purpose, so we can run the app and test the library as we develop it.

Once this is merged, we can remove [mediasoup-broadcaster-demo](https://github.com/versatica/mediasoup-broadcaster-demo) which is unmaintained and most probably not working, and use this app instead, which connects as a regular user.

NOTE 3: I may probably stick to `Listener` callback pattern all around. In some places I'm passing callbacks in constructor arguments, and in some other I'm passing the parent object to the child does `parent.onFooBar()` which is not nice.