### PR TITLE
Disable libcxx_modules for linux

### DIFF
--- a/.github/workflows/build-libwebrtc.yml
+++ b/.github/workflows/build-libwebrtc.yml
@@ -17,14 +17,30 @@ jobs:
             fail-fast: false
             matrix:
                 build:
-                    # TODO: Linux build disabled as it fails.
-                    #- os: ubuntu-24.04
-                    #  artifact: libwebrtc-linux-x64
-                    #  gn_args: is_debug=false is_component_build=false is_clang=true rtc_include_tests=false rtc_use_h264=true use_rtti=true use_custom_libcxx=false treat_warnings_as_errors=false
+                    - os: ubuntu-24.04
+                      artifact: libwebrtc-linux-x64
+                      gn_args: >-
+                          is_debug=false
+                          is_component_build=false
+                          is_clang=true
+                          rtc_include_tests=false
+                          rtc_use_h264=true
+                          use_rtti=true
+                          use_custom_libcxx=false
+                          use_libcxx_modules=false
+                          treat_warnings_as_errors=false
 
                     - os: macos-15
                       artifact: libwebrtc-macos-arm64
-                      gn_args: is_debug=false is_component_build=false is_clang=true rtc_include_tests=false rtc_use_h264=true treat_warnings_as_errors=false use_rtti=true use_custom_libcxx=false
+                      gn_args: >-
+                          is_debug=false
+                          is_component_build=false
+                          is_clang=true
+                          rtc_include_tests=false
+                          rtc_use_h264=true
+                          use_rtti=true
+                          use_custom_libcxx=false
+                          treat_warnings_as_errors=false
 
         name: Build (${{ matrix.build.os }})
         runs-on: ${{ matrix.build.os }}


### PR DESCRIPTION
It seems that we are hitting a linux specific libc++ module issue based on the CI errors.