### PR TITLE
fix: extract rtp capabilities crash

### DIFF
--- a/src/sdp/Utils.cpp
+++ b/src/sdp/Utils.cpp
@@ -32,6 +32,9 @@ namespace mediasoupclient
 
 				for (const auto& m : sdpObject["media"])
 				{
+					if (m["port"] == 0)
+						continue;
+					
 					auto kind = m["type"].get<std::string>();
 
 					if (kind == "audio")


### PR DESCRIPTION
Fixes #192.                                                                                                                                                                        
                                                                                                                                                                                     
                                                                                                                                                                                     
Hit this on Android, libmediasoupclient 3.5.0 + libwebrtc M140. Reproduces when the only m=audio section in the SDP is rejected and a video produce runs. We only got there by alternating the mic and camera buttons quickly.

The offer at that moment, the live video section and the rejected audio one:                                                                                                        
                                                                                                                                                                                     
```
  m=video 55603 UDP/TLS/RTP/SAVPF 96 97 98 ...                                                                                                                                       
  a=mid:0                                                                                                                                                                            
  a=sendonly                                                                                                                                                                         
  a=extmap:1 ... a=extmap:14                       <- 13 extmap lines                                                                                                                
  a=rtpmap:96 VP8/90000                                                                                                                                                              
                                                                                                                                                                                     
  m=audio 0 UDP/TLS/RTP/SAVPF 111 63 9 0 8 13 110 126                                                                                                                                
  a=mid:44                                                                                                                                                                           
  a=inactive                                                                                                                                                                         
  a=rtpmap:111 opus/48000/2                                                                                                                                                          
  a=rtcp-fb:111 transport-cc                                                                                                                                                         
  a=fmtp:111 minptime=10;useinbandfec=1            <- no extmap at all    
```                                                                                                           
                                                                                                                                                                                     
  Utils.cpp:136 then reads a key that is not there, on a const json&:                                                                                                                
                                                                                                                                                                                     
`  for (const auto& ext : m["ext"])`

The call is a video produce, but it dies on the audio section - the mic was off, so the only m=audio in the SDP was the rejected one.                                              
                                                                                                                                                                                     
  [DEBUG] Handler::Send() | [kind:video, track->id():ARDAMSv0]                                                                                                                       
  [TRACE] PeerConnection::CreateOffer()                                                                                                                                              
  [TRACE] Sdp::Utils::extractRtpCapabilities()                                                                                                                                       
  [ERROR] transport_jni::JNI_SendTransport_Produce() | [json.exception.type_error.305] cannot use operator[] with a string argument with number                                      
